### PR TITLE
Fixed other production top locations at national level

### DIFF
--- a/src/components/sections/ExploreData/Production/ProductionTopLocations.js
+++ b/src/components/sections/ExploreData/Production/ProductionTopLocations.js
@@ -148,7 +148,7 @@ const ProductionTopLocations = ({ title, ...props }) => {
     }
     else {
 
-      const unitAbbr = data.state_fiscal_production_summary[0].unit_abbr
+      const unitAbbr = data.fiscal_production_summary[0].unit_abbr
       chartData = d3.nest()
         .key(k => k.location_name)
         .rollup(v => d3.sum(v, i => i.sum))

--- a/src/components/sections/ExploreData/Production/ProductionTopLocations.js
+++ b/src/components/sections/ExploreData/Production/ProductionTopLocations.js
@@ -147,7 +147,16 @@ const ProductionTopLocations = ({ title, ...props }) => {
         })
     }
     else {
-      chartData =  data.fiscal_production_summary
+
+      const unitAbbr = data.state_fiscal_production_summary[0].unit_abbr
+      chartData = d3.nest()
+        .key(k => k.location_name)
+        .rollup(v => d3.sum(v, i => i.sum))
+        .entries(data.fiscal_production_summary).map(item => {
+          const r = { sum: item.value, location_name: item.key, unit_abbr: unitAbbr }
+          return r
+        })
+      //chartData =  data.fiscal_production_summary
     }
       console.debug("CHART DATA", chartData)
     return (


### PR DESCRIPTION
Fixes #514 
[:sunglasses: PREVIEW](https://514-Otherproduction.app.cloud.gov/explore/)

Changes proposed in this pull request:
State cards were fixed but other for national and native were still summing other top locations incorrectly

-
-
-