### PR TITLE
Fixes broken links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7171,8 +7171,7 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "optional": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -15889,9 +15888,9 @@
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -15899,9 +15898,9 @@
       },
       "dependencies": {
         "eventemitter3": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.3.tgz",
-          "integrity": "sha512-HyaFeyfTa18nYjft59vEPsvuq6ZVcrCC1rBw6Fx8ZV9NcuUITBNCnTOyr0tHHkkHn//d+lzhsL1YybgtLQ7lng=="
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
         }
       }
     },
@@ -16321,14 +16320,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "optional": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "optional": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -16360,7 +16357,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -16368,8 +16364,7 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "optional": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -16386,8 +16381,7 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "optional": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -16415,7 +16409,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -24850,7 +24843,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
       "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-      "optional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -23,7 +23,7 @@ tags:
 
 The United States is a major developer of natural resources. The Department of the Interior (DOI) collects billions of dollars in annual revenue
 from companies that lease <GlossaryTerm>federal lands and waters</GlossaryTerm> in order to develop oil, gas, or mineral
-resources. These revenues are <Link href="/how-revenue-works#understanding-federal-disbursements">disbursed</Link> to the U.S. Treasury, other federal agencies, states, 
+resources. These revenues are <Link href="/how-revenue-works#understanding-federal-disbursements">disbursed</Link> to the U.S. Treasury, other federal agencies, states,
 Native American tribes, and individual Native American mineral owners.
 
 This site provides data and contextual information about how natural resources and their revenues are managed in the U.S.
@@ -37,8 +37,8 @@ This site provides data and contextual information about how natural resources a
 **Understand natural resource management on federal land**
 
  * [Land ownership](/how-revenue-works/ownership/)
- * [Laws and regulations](/how-revenue-works/#laws)
- * [Oil, gas, minerals, and renewable energy](/how-revenue-works/#process)
+ * [Laws and regulations](/how-revenue-works/#what-laws-regulations-govern-natural-resource-extraction-in-the-us)
+ * [Oil, gas, minerals, and renewable energy](/how-revenue-works/#the-production-process)
  * [Audits and assurances](/how-revenue-works/audits-and-assurances/)
 
 </Grid>

--- a/src/pages/how-revenue-works/aml-reclamation-program.mdx
+++ b/src/pages/how-revenue-works/aml-reclamation-program.mdx
@@ -31,9 +31,9 @@ State and tribal AML programs rank abandoned mine land problems on a priority sc
 
 ### Map of sites
 
-To see AML data by location, visit the <glossary-term>OSMRE</glossary-term> [data site](https://amlis.osmre.gov/Map.aspx) and click on 'Mapping' in the navigation bar. 
+To see AML data by location, visit the <glossary-term>OSMRE</glossary-term> [data site](https://amlis.osmre.gov/Map.aspx) and click on 'Mapping' in the navigation bar.
 
-To see data by completed, funded, and unfunded sites, click on 'Summary.' 
+To see data by completed, funded, and unfunded sites, click on 'Summary.'
 
 [<AmlOsmreMapImg />](https://amlis.osmre.gov/Map.aspx)
 
@@ -41,16 +41,16 @@ To see data by completed, funded, and unfunded sites, click on 'Summary.'
 
 The federal AML Reclamation Program distributes funds for reclamation to the state and tribal AML programs with remaining Priority 1 and 2 sites.
 
-State and tribal AML programs use funds to prepare for reclamation projects, including: 
+State and tribal AML programs use funds to prepare for reclamation projects, including:
 
 - permitting processes
 - environmental assessments
 - site surveys
-- development of reclamation plans 
+- development of reclamation plans
 
 After completing project preparation, funds are used for construction to reclaim the site.
 
-OSMRE is required to report measurable goals to Congress. One of their key measures is the number of abandoned mine land acres reclaimed. 
+OSMRE is required to report measurable goals to Congress. One of their key measures is the number of abandoned mine land acres reclaimed.
 
 ## Revenue and disbursements
 
@@ -64,7 +64,7 @@ Companies pay a [per-ton fee to OSMRE](https://www.gpo.gov/fdsys/granule/USCODE-
 
 Congress set the current rates when the fee was extended in the Tax Relief and Health Care Act of 2006, lowering the rates 20% from the original amounts set in 1977.
 
-Interest from AML fees pays for a portion of the costs for [health care plans for the United Mine Workers of America (UMWA)](#interest-on-the-fund).
+Interest from AML fees pays for a portion of the costs for [health care plans for the United Mine Workers of America (UMWA)](#Interest-on-the-fund).
 
 ### Fund distribution
 

--- a/src/pages/how-revenue-works/gomesa.mdx
+++ b/src/pages/how-revenue-works/gomesa.mdx
@@ -20,15 +20,15 @@ tags:
 
 # Gulf of Mexico Energy Security Act (GOMESA)
 
-The Gulf of Mexico Energy Security Act (GOMESA) of 2006 created a revenue-sharing model for oil- and gas-producing gulf states. Under the act, Alabama, Louisiana, Mississippi, and Texas receive a portion of the revenue generated from oil and gas production offshore in the Gulf of Mexico. The act also directs a portion of revenue to the Land and Water Conservation Fund.   
+The Gulf of Mexico Energy Security Act (GOMESA) of 2006 created a revenue-sharing model for oil- and gas-producing gulf states. Under the act, Alabama, Louisiana, Mississippi, and Texas receive a portion of the revenue generated from oil and gas production offshore in the Gulf of Mexico. The act also directs a portion of revenue to the Land and Water Conservation Fund.
 
 ## Revenue sharing
 The [Gulf of Mexico Energy Security Act of 2006 (PDF)](https://www.boem.gov/GOMESA/) (GOMESA) created revenue-sharing provisions for four states and their <GlossaryTerm>coastal political subdivisions</GlossaryTerm>:
 
-* [Alabama](/explore/AL/#disbursements)
-* [Louisiana](/explore/LA/#disbursements)
-* [Mississippi](/explore/MS/#disbursements)
-* [Texas](/explore/TX/#disbursements)
+* Alabama
+* Louisiana
+* Mississippi
+* Texas
 
 ### GOMESA disbursements
 
@@ -42,15 +42,15 @@ The Office of Natural Resources Revenue disburses GOMESA revenue to both state a
     </TableRow>
     </TableHead>
     <TableBody>
-        <TableRow><TableCell><a href="/explore/AL#federal-disbursements">Alabama</a></TableCell><TableCell>$30,595,109.50</TableCell></TableRow>
-        <TableRow><TableCell><a href="/explore/LA#federal-disbursements">Louisiana</a></TableCell><TableCell>$94,728,191.78</TableCell></TableRow>
-        <TableRow><TableCell><a href="/explore/MS#federal-disbursements">Mississippi</a></TableCell><TableCell>$31,723,855.95</TableCell></TableRow>
-        <TableRow><TableCell><a href="/explore/TX#federal-disbursements">Texas</a></TableCell><TableCell>$57,891,839.04</TableCell></TableRow>
+        <TableRow><TableCell>Alabama</TableCell><TableCell>$30,595,109.50</TableCell></TableRow>
+        <TableRow><TableCell>Louisiana</TableCell><TableCell>$94,728,191.78</TableCell></TableRow>
+        <TableRow><TableCell>Mississippi</TableCell><TableCell>$31,723,855.95</TableCell></TableRow>
+        <TableRow><TableCell>Texas</TableCell><TableCell>$57,891,839.04</TableCell></TableRow>
     </TableBody>
-</Table> 
+</Table>
 
 ### Land and Water Conservation Fund
-The act also directs a portion of gulf revenue to the [Land and Water Conservation Fund](/how-revenue-works/land-and-water-conservation-fund/), which supports preservation, development, and access to outdoor lands for public recreation.
+The act also directs a portion of gulf revenue to the [Land and Water Conservation Fund](/how-revenue-works/lwcf/), which supports preservation, development, and access to outdoor lands for public recreation.
 
 ### Purpose of funds
 GOMESA funds are to be used for coastal conservation, restoration, and hurricane protection.

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -56,7 +56,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       <TableCell>Offshore</TableCell>
       <TableCell><strong>Bonus</strong></TableCell>
       <TableCell><strong>Water depth 0–200m:</strong> Years 1–5 rent is $7/acre, year 6 rent is $14/acre, year 7 rent is $21/acre, year 8+ rent is $28/acre<br />
-      <strong>Water depth 200–400m:</strong> Years 1–5 rent is $11/acre, year 6 rent is $22/acre, year 7 rent is $33/acre, year 8+ rent is $44/acre<br /> 
+      <strong>Water depth 200–400m:</strong> Years 1–5 rent is $11/acre, year 6 rent is $22/acre, year 7 rent is $33/acre, year 8+ rent is $44/acre<br />
       <strong>Water depth 400+:</strong> Years 1–5 rent is $11/acre, years 6+ rent is $16/acre
       </TableCell>
       <TableCell><strong>12.5%</strong> for leases located in water depths less than 200 meters<br />
@@ -213,7 +213,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       <TableCell>Direct-use fees for energy needs other than the commercial production or generation of electricity</TableCell>
       <TableCell>Electricity sales: <strong>1.75%</strong> of gross proceeds for 10 years, then <strong>3.5%</strong><br /><br />
           Arm’s length sales: <strong>10%</strong> of gross proceeds from contract multiplied by lease royalty rate
-      </TableCell>    
+      </TableCell>
     </TableRow>
     <TableRow>
       <TableCell>Noncompetitive leasing</TableCell>
@@ -269,7 +269,7 @@ The Treasury estimates the total dollar amount of each tax expenditure in a give
 
 ### Federal budget process
 
-Once revenue is collected by the federal government, it passes through a series of budgetary gateways before ultimately funding public services and community development. These gateways are described below, and you can [explore disbursement data here](/explore/#federal-disbursements).
+Once revenue is collected by the federal government, it passes through a series of budgetary gateways before ultimately funding public services and community development. These gateways are described below, and you can [explore disbursement data here](/explore?dataType=Disbursements).
 
 <Box mt={4} mb={4}>
 <FederalBudgetProcessImg />


### PR DESCRIPTION
Fixes #497, #499, #500, #501

[:sunglasses: PREVIEW](https://fix-links.app.cloud.gov/explore/)

Fixes links:
- LWCF link on GOMESA page
- UMWA link on AML page
- Disbursements link on Revenues page
- Two links on About page
- Removes state links on GOMESA page (temporary fix for #494)