### PR TITLE
added commodity order to queries

### DIFF
--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -6,7 +6,7 @@ export const client = new ApolloClient({
 
   cache: new InMemoryCache(),
   link: new HttpLink({
-    uri: 'https://hasura-onrr.app.cloud.gov/v1/graphql',
+    uri: 'https://hasura-sandbox.app.cloud.gov/v1/graphql',
     headers: {},
     fetch,
     resolvers: {}

--- a/src/js/data-filter-query-manager/production-queries.js
+++ b/src/js/data-filter-query-manager/production-queries.js
@@ -167,8 +167,8 @@ const COMMODITY_OPTIONS_QUERY = `
       fiscal_year: {_in: $fiscalYear},
       calendar_year: {_in: $calendarYear}
     },
-    distinct_on: commodity,
-    order_by: {commodity: asc}
+    distinct_on: commodity_order,
+    order_by: {commodity_order: asc}
   ) {
     option:commodity
   }`

--- a/src/js/data-filter-query-manager/revenue-queries.js
+++ b/src/js/data-filter-query-manager/revenue-queries.js
@@ -197,8 +197,8 @@ const COMMODITY_OPTIONS_QUERY = `
       fiscal_year: {_in: $fiscalYear},
       calendar_year: {_in: $calendarYear}
     },
-    distinct_on: commodity,
-    order_by: {commodity: asc}
+    distinct_on: commodity_order,
+    order_by: {commodity_order: asc}
   ) {
     option:commodity
   }`


### PR DESCRIPTION
Fixes #346 

[:sunglasses: PREVIEW](https://346-highest-value-commodites-first.app.cloud.gov/query-data)

Changes proposed in this pull request:

- Order of commodities is according tp the commodity order
-
-