### PR TITLE
Fixed Prodution top locations from erroring out if state had no data

### DIFF
--- a/src/components/sections/ExploreData/Production/ProductionTopLocations.js
+++ b/src/components/sections/ExploreData/Production/ProductionTopLocations.js
@@ -154,7 +154,7 @@ const ProductionTopLocations = ({ title, ...props }) => {
   const dataSet = `FY ${ year }`
 
   if (data && (data.state_fiscal_production_summary.length || data.fiscal_production_summary.length)) {
-    if (location === 'County') {
+    if (data.state_fiscal_production_summary.length > 0  && location === 'County') {
       const unitAbbr = data.state_fiscal_production_summary[0].unit_abbr
       chartData = d3.nest()
         .key(k => k.location_name)


### PR DESCRIPTION
Fixes #586 

[:sunglasses: PREVIEW](https://586-NoDataError.app.cloud.gov/explore/)

Changes proposed in this pull request:

Fixed issue where state with no data is selected in production data. 

-
-
-