### PR TITLE
Revenue table: change to old headings and combine rents&fee

### DIFF
--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -145,6 +145,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
     <TableRow>
       <TableCell style="border-bottom: none"></TableCell>
       <TableCell colSpan="3" style="text-align:center">Phase</TableCell>
+      <TableCell></TableCell>
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
@@ -159,11 +160,11 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       <TableCell>
         <strong>$15</strong> per acre application filing fee (outside designated leasing areas)
       </TableCell>
-      <TableCell><strong>Rent</strong> determined by number of acres multiplied by zone rate<br /><br />
-      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">Review the details</a>
-      Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br /><br />
-      <strong>$5,010</strong> megawatt capacity fee for wind<br /><br />
-      <a href="https://www.blm.gov/policy/im-2017-096">Review the details</a>
+      <TableCell><strong>Rent</strong> determined by number of acres multiplied by zone rate<br />
+      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">(Review the details.)</a><br />
+      Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br />
+      <strong>$5,010</strong> megawatt capacity fee for wind
+      <a href="https://www.blm.gov/policy/im-2017-096">(Review the details.)</a>
       </TableCell>
     </TableRow>
     <TableRow>

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -162,7 +162,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       </TableCell>
       <TableCell><strong>Rent</strong> determined by number of acres multiplied by zone rate<br /><br />
       <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">Review the details</a>
-      <strong>Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br /><br />
+      Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br /><br />
       <strong>$5,010</strong> megawatt capacity fee for wind<br /><br />
       <a href="https://www.blm.gov/policy/im-2017-096">Review the details</a>
       </TableCell>

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -161,24 +161,25 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
         <strong>$15</strong> per acre application filing fee (outside designated leasing areas)
       </TableCell>
       <TableCell><strong>Rent</strong> determined by number of acres multiplied by zone rate<br />
-      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">(Review the details.)</a><br />
-      Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br />
+      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy"> (Review the details)</a><br /><br />
+      <strong>$2,863</strong> to <strong>$4,294</strong> for solar megawatt capacity fees, varying based on technology<br />
       <strong>$5,010</strong> megawatt capacity fee for wind
-      <a href="https://www.blm.gov/policy/im-2017-096">(Review the details.)</a>
+      <a href="https://www.blm.gov/policy/im-2017-096"> (Review the details)</a>
       </TableCell>
+      <TableCell></TableCell>
     </TableRow>
     <TableRow>
       <TableCell>Offshore (wind)</TableCell>
       <TableCell><strong>Bonus</strong> (competitive lease)<br />
           <strong>$0.25</strong> per acre for acquisition fee (uncompetitive lease)</TableCell>
       <TableCell><strong>$3</strong> annual rent per acre</TableCell>
-      <TableCell><strong>2%</strong> of anticipated value of wind energy produced in operating fee*<br />
+      <TableCell><strong>2%</strong> of anticipated value of wind energy produced in operating fee unless waived or otherwise specified<br />
       </TableCell>
     </TableRow>
   </TableBody>
 </Table>
 
-* Unless waived or otherwise specified
+
 
 #### <IconGeothermalImg /> Geothermal
 

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -36,7 +36,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
   <TableHead>
     <TableRow>
       <TableCell style="border-bottom: none"></TableCell>
-      <TableCell colSpan="3">Phase</TableCell>
+      <TableCell colSpan="3" style="text-align:center">Phase</TableCell>
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
@@ -72,7 +72,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
   <TableHead>
     <TableRow>
       <TableCell style="border-bottom: none"></TableCell>
-      <TableCell colSpan="3">Phase</TableCell>
+      <TableCell colSpan="3" style="text-align:center">Phase</TableCell>
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
@@ -107,7 +107,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
   <TableHead>
     <TableRow>
       <TableCell style="border-bottom: none"></TableCell>
-      <TableCell colSpan="3">Phase</TableCell>
+      <TableCell colSpan="3" style="text-align:center">Phase</TableCell>
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
@@ -133,7 +133,6 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       <TableCell><strong>$1,000</strong> minimum bond for prospecting permits<br />
           <strong>$5,000</strong> minimum bond for leases</TableCell>
       <TableCell><strong>$0.50</strong> per acre or fraction of an acre</TableCell>
-      <TableCell></TableCell>
       <TableCell>Royalty rates are exempt from minimums and determined on an individual basis by the authorized leasing officers.</TableCell>
     </TableRow>
   </TableBody>
@@ -145,7 +144,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
   <TableHead>
     <TableRow>
       <TableCell style="border-bottom: none"></TableCell>
-      <TableCell colSpan="3">Phase</TableCell>
+      <TableCell colSpan="3" style="text-align:center">Phase</TableCell>
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
@@ -186,7 +185,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
   <TableHead>
     <TableRow>
       <TableCell style="border-bottom: none"></TableCell>
-      <TableCell colSpan="3">Phase</TableCell>
+      <TableCell colSpan="3" style="text-align:center">Phase</TableCell>
     </TableRow>
     <TableRow>
       <TableCell></TableCell>

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -166,6 +166,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       <strong>$5,010</strong> megawatt capacity fee for wind<br /><br />
       <a href="https://www.blm.gov/policy/im-2017-096">Review the details</a>
       </TableCell>
+    </TableRow>
     <TableRow>
       <TableCell>Offshore (wind)</TableCell>
       <TableCell><strong>Bonus</strong> (competitive lease)<br />

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -216,7 +216,6 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
           <strong>$5</strong> annual rent per acre thereafter
       </TableCell>
       <TableCell></TableCell>
-      <TableCell></TableCell>
     </TableRow>
   </TableBody>
 </Table>

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -205,7 +205,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       <TableCell><strong>$2</strong> rent per acre for the first year<br />
           <strong>$3</strong> annual rent per acre for years 2–10<br />
           <strong>$5</strong> annual rent per acre after 10 years<br />
-      <strong>Direct-use fees for energy needs other than the commercial production or generation of electricity
+        Direct-use fees for energy needs other than the commercial production or generation of electricity
       </TableCell>
       <TableCell>Electricity sales: <strong>1.75%</strong> of gross proceeds for 10 years, then <strong>3.5%</strong><br /><br />
           Arm’s length sales: <strong>10%</strong> of gross proceeds from contract multiplied by lease royalty rate

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -128,6 +128,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       </TableCell>
       <TableCell></TableCell>
     </TableRow>
+      <TableRow>
       <TableCell>Acquired lands</TableCell>
       <TableCell><strong>$1,000</strong> minimum bond for prospecting permits<br />
           <strong>$5,000</strong> minimum bond for leases</TableCell>
@@ -160,7 +161,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
         <strong>$15</strong> per acre application filing fee (outside designated leasing areas)
       </TableCell>
       <TableCell><strong>Rent</strong> determined by number of acres multiplied by zone rate<br /><br />
-      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">Review the details<br />
+      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">Review the details</a>
       <strong>Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br /><br />
       <strong>$5,010</strong> megawatt capacity fee for wind<br /><br />
       <a href="https://www.blm.gov/policy/im-2017-096">Review the details</a>
@@ -170,7 +171,7 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
       <TableCell><strong>Bonus</strong> (competitive lease)<br />
           <strong>$0.25</strong> per acre for acquisition fee (uncompetitive lease)</TableCell>
       <TableCell><strong>$3</strong> annual rent per acre</TableCell>
-      <TableCell><strong>2%</strong> of anticipated value of wind energy produced in operating fee*
+      <TableCell><strong>2%</strong> of anticipated value of wind energy produced in operating fee*<br />
       </TableCell>
     </TableRow>
   </TableBody>

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -40,9 +40,9 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
-      <TableCell>Bonus</TableCell>
-      <TableCell>Rent</TableCell>
-      <TableCell>Royalty</TableCell>
+      <TableCell>Securing a lease or claim</TableCell>
+      <TableCell>Before Production</TableCell>
+      <TableCell>During Production</TableCell>
     </TableRow>
   </TableHead>
   <TableBody>
@@ -76,9 +76,9 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
-      <TableCell>Bonus</TableCell>
-      <TableCell>Rent</TableCell>
-      <TableCell>Royalty</TableCell>
+      <TableCell>Securing a lease or claim</TableCell>
+      <TableCell>Before production</TableCell>
+      <TableCell>During production</TableCell>
     </TableRow>
   </TableHead>
   <TableBody>
@@ -111,25 +111,23 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
-      <TableCell>Bonus</TableCell>
-      <TableCell>Rent</TableCell>
-      <TableCell>Fee</TableCell>
-      <TableCell>Royalty</TableCell>
+      <TableCell>Securing a lease or claim</TableCell>
+      <TableCell>Before production</TableCell>
+      <TableCell>During production</TableCell>
     </TableRow>
   </TableHead>
   <TableBody>
     <TableRow>
       <TableCell>Public domain lands</TableCell>
       <TableCell></TableCell>
-      <TableCell><strong>$1</strong> per acre</TableCell>
-      <TableCell><strong>$20</strong> processing fee<br />
+      <TableCell><strong>$1</strong> per acre<br />
+          <strong>$20</strong> processing fee<br />
           <strong>$40</strong> location fee<br />
           <strong>$165</strong> initial maintenance fee<br />
           <strong>$165</strong> annual maintenance fee for the assessment year in which the claim/site was located
       </TableCell>
       <TableCell></TableCell>
     </TableRow>
-    <TableRow>
       <TableCell>Acquired lands</TableCell>
       <TableCell><strong>$1,000</strong> minimum bond for prospecting permits<br />
           <strong>$5,000</strong> minimum bond for leases</TableCell>
@@ -150,10 +148,9 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
-      <TableCell>Bonus</TableCell>
-      <TableCell>Rent</TableCell>
-      <TableCell>Fee</TableCell>
-      <TableCell>Royalty</TableCell>
+      <TableCell>Securing a lease or claim</TableCell>
+      <TableCell>Before production</TableCell>
+      <TableCell>During production</TableCell>
     </TableRow>
   </TableHead>
   <TableBody>
@@ -163,18 +160,16 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
         <strong>$15</strong> per acre application filing fee (outside designated leasing areas)
       </TableCell>
       <TableCell><strong>Rent</strong> determined by number of acres multiplied by zone rate<br /><br />
-      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">Review the details</a></TableCell>
-      <TableCell>Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br /><br />
+      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">Review the details<br />
+      <strong>Solar megawatt capacity fees vary by technology, ranging from <strong>$2,863</strong> to <strong>$4,294</strong><br /><br />
       <strong>$5,010</strong> megawatt capacity fee for wind<br /><br />
       <a href="https://www.blm.gov/policy/im-2017-096">Review the details</a>
       </TableCell>
-    </TableRow>
     <TableRow>
       <TableCell>Offshore (wind)</TableCell>
       <TableCell><strong>Bonus</strong> (competitive lease)<br />
           <strong>$0.25</strong> per acre for acquisition fee (uncompetitive lease)</TableCell>
       <TableCell><strong>$3</strong> annual rent per acre</TableCell>
-      <TableCell></TableCell>
       <TableCell><strong>2%</strong> of anticipated value of wind energy produced in operating fee*
       </TableCell>
     </TableRow>
@@ -193,10 +188,9 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
     </TableRow>
     <TableRow>
       <TableCell></TableCell>
-      <TableCell>Bonus</TableCell>
-      <TableCell>Rent</TableCell>
-      <TableCell>Fee</TableCell>
-      <TableCell>Royalty</TableCell>
+      <TableCell>Securing a lease or claim</TableCell>
+      <TableCell>Before production</TableCell>
+      <TableCell>During production</TableCell>
     </TableRow>
   </TableHead>
   <TableBody>
@@ -206,11 +200,11 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
         <strong>$115</strong> nomination fee and <strong>$0.12</strong> per acre<br />
         <strong>$165</strong> application fee
       </TableCell>
-      <TableCell><strong>$2</strong> per acre for the first year<br />
+      <TableCell><strong>$2</strong> rent per acre for the first year<br />
           <strong>$3</strong> annual rent per acre for years 2–10<br />
-          <strong>$5</strong> annual rent per acre after 10 years
+          <strong>$5</strong> annual rent per acre after 10 years<br />
+      <strong>Direct-use fees for energy needs other than the commercial production or generation of electricity
       </TableCell>
-      <TableCell>Direct-use fees for energy needs other than the commercial production or generation of electricity</TableCell>
       <TableCell>Electricity sales: <strong>1.75%</strong> of gross proceeds for 10 years, then <strong>3.5%</strong><br /><br />
           Arm’s length sales: <strong>10%</strong> of gross proceeds from contract multiplied by lease royalty rate
       </TableCell>

--- a/src/pages/how-revenue-works/revenues.mdx
+++ b/src/pages/how-revenue-works/revenues.mdx
@@ -161,12 +161,12 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
         <strong>$15</strong> per acre application filing fee (outside designated leasing areas)
       </TableCell>
       <TableCell><strong>Rent</strong> determined by number of acres multiplied by zone rate<br />
-      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy"> (Review the details)</a><br /><br />
+      <a href="https://www.federalregister.gov/documents/2016/12/19/2016-27551/competitive-processes-terms-and-conditions-for-leasing-public-lands-for-solar-and-wind-energy">(Review the details)</a><br /><br />
       <strong>$2,863</strong> to <strong>$4,294</strong> for solar megawatt capacity fees, varying based on technology<br />
-      <strong>$5,010</strong> megawatt capacity fee for wind
-      <a href="https://www.blm.gov/policy/im-2017-096"> (Review the details)</a>
+      <strong>$5,010</strong> megawatt capacity fee for wind<br />
+      <a href="https://www.blm.gov/policy/im-2017-096">(Review the details)</a>
       </TableCell>
-      <TableCell></TableCell>
+      <TableCell> </TableCell>
     </TableRow>
     <TableRow>
       <TableCell>Offshore (wind)</TableCell>


### PR DESCRIPTION
Fixes #415 

[:sunglasses: PREVIEW](https://revenuetable.app.cloud.gov/how-revenue-works/revenues)

Changes proposed in this pull request:

- Rename headings to "Secure Lease or Claim, Before production, and During Production"
- Combine rents & fees together under the Before production phase 