### PR TITLE
Fix Download Query Data

### DIFF
--- a/src/components/data-viz/DataTable/DataTable.js
+++ b/src/components/data-viz/DataTable/DataTable.js
@@ -301,7 +301,8 @@ const DataTableBase = ({ data, showSummaryRow, showOnlySubtotalRow }) => {
       setFixedColumns([columnNames[0]])
     }
     setColumnOrder(getColumnOrder())
-    setHiddenColumnNames(getHiddenColumns())
+    const hiddenCols = getHiddenColumns()
+    setHiddenColumnNames(hiddenCols)
     setGroupSummaryItems(getGroupSummaryItems())
     setTotalSummaryItems(getTotalSummaryItems())
 
@@ -328,7 +329,7 @@ const DataTableBase = ({ data, showSummaryRow, showOnlySubtotalRow }) => {
           addDownloadData({
             key: DOWNLOAD_DATA_TABLE,
             data: {
-              cols: columnNames.filter(col => !hiddenColumnNames.includes(col.name)),
+              cols: columnNames.filter(col => !hiddenCols.includes(col.name)),
               rows: sums
             }
           })


### PR DESCRIPTION
Fixes #678 

[:sunglasses: PREVIEW](https://678-fix-downloads.app.cloud.gov/query-data)

Changes proposed in this pull request:

- Download columns now will match what is selected
-
-