### PR TITLE
removed county filter

### DIFF
--- a/src/components/toolbars/QueryTableToolbar/QueryTableToolbar.js
+++ b/src/components/toolbars/QueryTableToolbar/QueryTableToolbar.js
@@ -257,25 +257,21 @@ const isCountyEnabled = ({ state }) => (state[STATE_OFFSHORE_NAME] &&
   (!state[STATE_OFFSHORE_NAME].includes('Not')))
 
 const RevenueFilterToolbar = () => {
-  const countyEnabled = isCountyEnabled(useContext(DataFilterContext))
   return (
     <BaseToolbar isSecondary={true} >
       <LandTypeSelectInput />
       <RevenueTypeSelectInput />
       <StateOffshoreSelectInput />
-      <CountySelectInput helperText={countyEnabled ? undefined : 'Select a single State to view County options.'} disabled={!countyEnabled} />
       <CommoditySelectInput />
     </BaseToolbar>
   )
 }
 
 const ProductionFilterToolbar = () => {
-  const countyEnabled = isCountyEnabled(useContext(DataFilterContext))
   return (
     <BaseToolbar isSecondary={true} >
       <LandTypeSelectInput />
       <StateOffshoreSelectInput />
-      <CountySelectInput helperText={countyEnabled ? undefined : 'Select a single State to view County options.'} disabled={!countyEnabled} />
       <ProductSelectInput />
     </BaseToolbar>
   )


### PR DESCRIPTION
Fixes #725

[:sunglasses: PREVIEW](https://725-remove-county-filter.app.cloud.gov/query-data/)

Changes proposed in this pull request:

- Removed the option to filter by county on revenue and production
-
-