### PR TITLE
made changes to filters/grouping/values for disbursements query tool

### DIFF
--- a/src/components/toolbars/QueryTableToolbar/QueryTableToolbar.js
+++ b/src/components/toolbars/QueryTableToolbar/QueryTableToolbar.js
@@ -279,13 +279,11 @@ const ProductionFilterToolbar = () => {
 }
 
 const DisbursementFilterToolbar = () => {
-  const countyEnabled = isCountyEnabled(useContext(DataFilterContext))
   return (
     <BaseToolbar isSecondary={true} >
       <RecipientSelectInput />
       <SourceSelectInput />
       <StateNameSelectInput defaultSelectAll={false} />
-      <CountySelectInput helperText={countyEnabled ? undefined : 'Select a single State to view County options.'} disabled={!countyEnabled} />
     </BaseToolbar>
   )
 }

--- a/src/constants/data-filter-constants.js
+++ b/src/constants/data-filter-constants.js
@@ -34,6 +34,7 @@ export const RECIPIENT = 'recipient'
 export const SOURCE = 'source'
 export const STATE_OFFSHORE_NAME = 'stateOffshoreName'
 export const MAP_LEVEL = 'mapLevel'
+export const LOCAL_RECIPIENT = 'localRecipient'
 
 export const PERIOD_FISCAL_YEAR = 'Fiscal Year'
 export const PERIOD_CALENDAR_YEAR = 'Calendar Year'
@@ -196,4 +197,8 @@ export const DISPLAY_NAMES = {
     default: 'Calendar year',
     plural: 'Calendar years',
   },
+  [LOCAL_RECIPIENT]: {
+    default: 'Local recipient',
+    plural: 'Local recipients'
+  }
 }

--- a/src/js/data-filter-query-manager/disbursement-queries.js
+++ b/src/js/data-filter-query-manager/disbursement-queries.js
@@ -24,7 +24,6 @@ const VARIABLE_LIST = ''.concat(
   '$source: [String!],',
   '$state: [String!],',
   '$state_name: [String!]',
-  '$county: [String!],',
   '$period: String,',
   '$fiscalYear: [Int!],',
   '$calendarYear: [Int!],',
@@ -38,7 +37,6 @@ const STATE_OFFSHORE_OPTIONS_QUERY = `
       state: {_in: $state},
       recipient: {_in: $recipient},
       source: {_in: $source},
-      county: {_in: $county},
       period: {_eq: $period},
       fiscal_year: {_in: $fiscalYear},
       calendar_year: {_in: $calendarYear},
@@ -57,7 +55,6 @@ const RECIPIENT_OPTIONS_QUERY = `
       state: {_in: $state},
       recipient: {_neq: ""},
       source: {_in: $source},
-      county: {_in: $county},
       period: {_eq: $period},
       fiscal_year: {_in: $fiscalYear},
       calendar_year: {_in: $calendarYear},
@@ -76,7 +73,6 @@ const SOURCE_OPTIONS_QUERY = `
       state: {_in: $state},
       recipient: {_in: $recipient},
       source: {_neq: ""},
-      county: {_in: $county},
       period: {_eq: $period},
       fiscal_year: {_in: $fiscalYear},
       calendar_year: {_in: $calendarYear},
@@ -95,7 +91,6 @@ const US_STATE_OPTIONS_QUERY = `
       state: {_neq: ""},
       recipient: {_in: $recipient},
       source: {_in: $source},
-      county: {_in: $county},
       period: {_eq: $period},
       fiscal_year: {_in: $fiscalYear},
       calendar_year: {_in: $calendarYear},
@@ -113,7 +108,6 @@ const US_STATE_NAME_OPTIONS_QUERY = `
       state_name: {_neq: ""},
       recipient: {_in: $recipient},
       source: {_in: $source},
-      county: {_in: $county},
       period: {_eq: $period},
       fiscal_year: {_in: $fiscalYear},
       calendar_year: {_in: $calendarYear},
@@ -125,25 +119,6 @@ const US_STATE_NAME_OPTIONS_QUERY = `
     option:state_name
   }`
 
-const COUNTY_OPTIONS_QUERY = `
-  options:${ GRAPHQL_VIEW }(
-    where: {
-      state_name: {_in: $state_name},
-      state: {_in: $state},
-      recipient: {_in: $recipient},
-      source: {_in: $source},
-      county: {_neq: ""},
-      period: {_eq: $period},
-      fiscal_year: {_in: $fiscalYear},
-      calendar_year: {_in: $calendarYear},
-      state_offshore_name: {_in: $${ STATE_OFFSHORE_NAME }}
-    },
-    distinct_on: county,
-    order_by: {county: asc}
-  ) {
-    option:county
-  }`
-
 const FISCAL_YEAR_OPTIONS_QUERY = `
   options:${ GRAPHQL_VIEW }(
     where: {
@@ -151,7 +126,6 @@ const FISCAL_YEAR_OPTIONS_QUERY = `
       recipient: {_in: $recipient},
       source: {_in: $source},
       state: {_in: $state},
-      county: {_in: $county},
       period: {_eq: $period},
       fiscal_year: {_neq: 0},
       state_offshore_name: {_in: $${ STATE_OFFSHORE_NAME }}
@@ -169,7 +143,6 @@ const CALENDAR_YEAR_OPTIONS_QUERY = `
       recipient: {_in: $recipient},
       source: {_in: $source},
       state: {_in: $state},
-      county: {_in: $county},
       period: {_eq: $period},
       calendar_year: {_neq: 0},
       state_offshore_name: {_in: $${ STATE_OFFSHORE_NAME }}
@@ -187,7 +160,6 @@ const PERIOD_OPTIONS_QUERY = `
       recipient: {_in: $recipient},
       source: {_in: $source},
       state: {_in: $state},
-      county: {_in: $county},
       state_offshore_name: {_in: $${ STATE_OFFSHORE_NAME }}
     },
     distinct_on: period,
@@ -199,7 +171,6 @@ const PERIOD_OPTIONS_QUERY = `
 const DISBURSEMENT_QUERIES = {
   [US_STATE_NAME]: gql`query GetUsStateNameOptionsDisbursement(${ VARIABLE_LIST }){${ US_STATE_NAME_OPTIONS_QUERY }}`,
   [US_STATE]: gql`query GetUsStateOptionsDisbursement(${ VARIABLE_LIST }){${ US_STATE_OPTIONS_QUERY }}`,
-  [COUNTY]: gql`query GetCountyOptionsDisbursement(${ VARIABLE_LIST }){${ COUNTY_OPTIONS_QUERY }}`,
   [RECIPIENT]: gql`query GetRecipientOptionsDisbursement(${ VARIABLE_LIST }){${ RECIPIENT_OPTIONS_QUERY }}`,
   [SOURCE]: gql`query GetSourceOptionsDisbursement(${ VARIABLE_LIST }){${ SOURCE_OPTIONS_QUERY }}`,
   [FISCAL_YEAR]: gql`query GetFiscalYearOptionsDisbursement(${ VARIABLE_LIST }){${ FISCAL_YEAR_OPTIONS_QUERY }}`,

--- a/src/js/query-manager/index.js
+++ b/src/js/query-manager/index.js
@@ -18,7 +18,8 @@ import {
   LAND_TYPE,
   PRODUCT,
   RECIPIENT,
-  SOURCE
+  SOURCE,
+  LOCAL_RECIPIENT
 } from '../../constants'
 
 import {
@@ -68,7 +69,8 @@ export const DATA_FILTER_KEY_TO_DB_COLUMNS = {
   [CALENDAR_YEAR]: 'calendar_year',
   [PRODUCT]: 'product',
   [RECIPIENT]: 'recipient',
-  [SOURCE]: 'source'
+  [SOURCE]: 'source',
+  [LOCAL_RECIPIENT]: 'local_recipient'
 }
 
 /**

--- a/src/js/query-manager/query-tool-data-table-queries.js
+++ b/src/js/query-manager/query-tool-data-table-queries.js
@@ -22,7 +22,8 @@ import {
   DATA_TYPE,
   STATE_OFFSHORE_NAME,
   FISCAL_YEAR,
-  CALENDAR_YEAR
+  CALENDAR_YEAR,
+  LOCAL_RECIPIENT
 } from '../../constants'
 import gql from 'graphql-tag'
 
@@ -106,7 +107,7 @@ const DISBURSEMENT_QUERY = variableConfig => {
     ${ RECIPIENT }: ${ DB_COLS[RECIPIENT] }
     ${ SOURCE }: ${ DB_COLS[SOURCE] }
     ${ US_STATE }: ${ DB_COLS[US_STATE_NAME] }
-    ${ COUNTY }: ${ DB_COLS[COUNTY_NAME] },
+    ${ LOCAL_RECIPIENT }: ${ DB_COLS[LOCAL_RECIPIENT] }
     ${ ALL_REVENUE_YEARS }
   }
   counts:query_tool_disbursement_data_aggregate (
@@ -116,9 +117,9 @@ const DISBURSEMENT_QUERY = variableConfig => {
     ) {
     aggregate {
       ${ RECIPIENT }:count(columns: ${ DB_COLS[RECIPIENT] }, distinct: true)
-      ${ COUNTY }:count(columns: ${ DB_COLS[COUNTY_NAME] }, distinct: true)
       ${ SOURCE }:count(columns: ${ DB_COLS[SOURCE] }, distinct: true)
       ${ US_STATE }:count(columns: ${ DB_COLS[US_STATE_NAME] }, distinct: true)
+      ${ LOCAL_RECIPIENT }:count(columns: ${ DB_COLS[LOCAL_RECIPIENT] }, distinct: true)
     }
   }`)
 }
@@ -153,7 +154,7 @@ const VARIABLE_CONFIGS = {
     { [RECIPIENT]: MULTI_STR },
     { [SOURCE]: MULTI_STR },
     { [US_STATE_NAME]: MULTI_STR },
-    { [COUNTY]: MULTI_STR },
+    { [LOCAL_RECIPIENT]: MULTI_STR },
     { [PERIOD]: SINGLE_STR },
     { [FISCAL_YEAR]: MULTI_INT },
     { [CALENDAR_YEAR]: MULTI_INT }


### PR DESCRIPTION
Fixes #718

[:sunglasses: PREVIEW](https://718-disbursements-update.app.cloud.gov/query-data?dataType=Disbursements)

Changes proposed in this pull request:

- Remove CY option, since we only have FY data
- Change "County" recipient to "State and local governments"
- Change "State/offshore region" label to just "State", since there are no disbursements to offshore regions
- Drops the ability to filter by county
- Only allow selecting or grouping by a state if you pick state and local governments recipient
- Change "county" to "local recipient" as a column available for grouping that includes the state and county level
- Pull GOMESA out of recipient names and have it as just a source
-