### PR TITLE
Fixed order of top locations array

### DIFF
--- a/src/components/sections/ExploreData/Production/ProductionTopLocations.js
+++ b/src/components/sections/ExploreData/Production/ProductionTopLocations.js
@@ -235,7 +235,7 @@ const ProductionTopLocations = ({ title, ...props }) => {
                   return d
                 }
               }
-              xLabel={locationType}
+              xLabel={'Location name'}
               yLabel={dataSet}
               maxCircles={6}
               minColor={theme.palette.green[100]}

--- a/src/components/sections/ExploreData/Revenue/RevenueTopLocations.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueTopLocations.js
@@ -28,7 +28,7 @@ const APOLLO_QUERY = gql`
   query RevenueTopLocations($year: Int!, $locations: [String!], $period: String!,  $commodities: [String!]) {
     revenue_summary(
       where: {location_type: {_in: $locations}, year: { _eq: $year }, location_name: {_neq: ""}, period: {_eq: $period}, commodity: {_in: $commodities}  },
-      order_by: { year: asc, total: desc }
+      order_by: {  total: desc }
     ) {
       location_name
       year
@@ -117,8 +117,8 @@ const RevenueTopLocations = ({ title, ...props }) => {
       .entries(data.revenue_summary)
       .map(d => {
         return ({ location_name: d.key, total: d.value })
-      })
-     // console.debug('CHART DATA', chartData)
+      }).sort((a, b) => (a.total < b.total) ? 1 : -1)
+
     return (
       <Container id={utils.formatToSlug(title)}>
         <Grid container>


### PR DESCRIPTION
Fixes #801 
[:sunglasses: PREVIEW](https://801-WrongOrderTopLocations.app.cloud.gov/explore/)

Changes proposed in this pull request:

Fixes the order of top locations - introduced when commodities were reflected as detail commodities are summed in client so the order was for the top commodities not the top state.   Sort after data is summarized


-
-
-