### PR TITLE
Adds land type parameter to urls

### DIFF
--- a/src/pages/how-revenue-works/native-american-production.mdx
+++ b/src/pages/how-revenue-works/native-american-production.mdx
@@ -201,4 +201,4 @@ Under a WSR, a developer must commence construction of the infrastructure within
 The WSR must stipulate what will happen to the infrastructure after the lease term, including who will own it, whether it will remain on the land, and whether it will be removed.
 
 ## Production on Native American land
- <ExploreDataLink to='/query-data/?dataType=Production' icon='filter'>Query production data</ExploreDataLink>
+ <ExploreDataLink to='/query-data/?dataType=Production&landType=Native%20American' icon='filter'>Query production data</ExploreDataLink>

--- a/src/pages/how-revenue-works/native-american-revenue.mdx
+++ b/src/pages/how-revenue-works/native-american-revenue.mdx
@@ -70,7 +70,7 @@ The federal government may only release information about natural resource extra
 
 [Documentation about the federal revenue dataset](/downloads/federal-revenue-by-location/)
 
-<ExploreDataLink to='/query-data/?dataType=Revenue' icon='filter'>Query revenue data</ExploreDataLink>
+<ExploreDataLink to='/query-data/?dataType=Revenue&landType=Native%20American' icon='filter'>Query revenue data</ExploreDataLink>
 
 ## Audits and assurances
 


### PR DESCRIPTION
Fixes #684

[:sunglasses: PREVIEW](https://query-links.app.cloud.gov/how-revenue-works/native-american-production/)

Changes proposed in this pull request:

- Adds &landType=Native%20American param to the urls from Native American production and revenue pages that link to query tool