### PR TITLE
Fixed logic error in productionLocationTotal; sometimes it caused err…

### DIFF
--- a/src/components/sections/ExploreData/Disbursements/DisbursementLocationTotal.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementLocationTotal.js
@@ -37,21 +37,31 @@ const DisbursementLocationTotal = props => {
   if (data) {
     const groupedLocationData = utils.groupBy(data.disbursement_summary, 'state_or_area')
 
-    nationwideSummary = d3.nest()
-      .key(k => k.state_or_area)
-      .rollup(v => d3.sum(v, i => i.sum))
-      .entries(groupedLocationData.NF)
-      .map(d => {
-        return ({ location_name: d.key, total: d.value })
-      })
+    if (groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS] && groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS].length > 0) {
+      nationwideSummary = d3.nest()
+        .key(k => k.state_or_area)
+        .rollup(v => d3.sum(v, i => i.sum))
+        .entries(groupedLocationData.NF)
+        .map(d => {
+          return ({ location_name: d.key, total: d.value })
+        })
+    }
+    else {
+      nationwideSummary = [{ location: DFC.NATIONWIDE_FEDERAL_FIPS, total: 0 }]
+    }
 
-    nativeSummary = d3.nest()
-      .key(k => k.state_or_area)
-      .rollup(v => d3.sum(v, i => i.sum))
-      .entries(groupedLocationData.NA)
-      .map(d => {
-        return ({ location_name: d.key, total: d.value })
-      })
+    if (groupedLocationData[DFC.NATIVE_AMERICAN_FIPS] && groupedLocationData[DFC.NATIVE_AMERICAN_FIPS].length > 0) {
+      nativeSummary = d3.nest()
+        .key(k => k.state_or_area)
+        .rollup(v => d3.sum(v, i => i.sum))
+        .entries(groupedLocationData.NA)
+        .map(d => {
+          return ({ location_name: d.key, total: d.value })
+        })
+    }
+    else {
+      nativeSummary.total = [{ location: DFC.NATIVE_AMERICAN_FIPS, total: 0 }]
+    }
 
     return (
       <>

--- a/src/components/sections/ExploreData/Production/ProductionLocationTotal.js
+++ b/src/components/sections/ExploreData/Production/ProductionLocationTotal.js
@@ -49,7 +49,7 @@ const ProductionLocationTotal = props => {
   if (data) {
     const groupedLocationData = utils.groupBy(data.production_summary, 'location')
 
-      if (groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS] && groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS].length > 0 ) {
+    if (groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS] && groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS].length > 0) {
       nationwideSummary = d3.nest()
         .key(k => k.location)
         .rollup(v => d3.sum(v, i => i.total))
@@ -62,7 +62,7 @@ const ProductionLocationTotal = props => {
       nationwideSummary = [{ location: DFC.NATIONWIDE_FEDERAL_FIPS, total: 0 }]
     }
 
-    if (groupedLocationData[DFC.NATIVE_AMERICAN_FIPS] && groupedLocationData[DFC.NATIVE_AMERICAN_FIPS].length > 0 ) {
+    if (groupedLocationData[DFC.NATIVE_AMERICAN_FIPS] && groupedLocationData[DFC.NATIVE_AMERICAN_FIPS].length > 0) {
       nativeSummary = d3.nest()
         .key(k => k.location)
         .rollup(v => d3.sum(v, i => i.total))

--- a/src/components/sections/ExploreData/Production/ProductionLocationTotal.js
+++ b/src/components/sections/ExploreData/Production/ProductionLocationTotal.js
@@ -49,7 +49,7 @@ const ProductionLocationTotal = props => {
   if (data) {
     const groupedLocationData = utils.groupBy(data.production_summary, 'location')
 
-    if (groupedLocationData[DFC.NATIVE_AMERICAN_FIPS]) {
+      if (groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS] && groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS].length > 0 ) {
       nationwideSummary = d3.nest()
         .key(k => k.location)
         .rollup(v => d3.sum(v, i => i.total))
@@ -62,7 +62,7 @@ const ProductionLocationTotal = props => {
       nationwideSummary = [{ location: DFC.NATIONWIDE_FEDERAL_FIPS, total: 0 }]
     }
 
-    if (groupedLocationData[DFC.NATIVE_AMERICAN_FIPS]) {
+    if (groupedLocationData[DFC.NATIVE_AMERICAN_FIPS] && groupedLocationData[DFC.NATIVE_AMERICAN_FIPS].length > 0 ) {
       nativeSummary = d3.nest()
         .key(k => k.location)
         .rollup(v => d3.sum(v, i => i.total))

--- a/src/components/sections/ExploreData/Revenue/RevenueLocationTotal.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueLocationTotal.js
@@ -46,21 +46,31 @@ const RevenueLocationTotal = props => {
     // console.log('LocationTotal data: ', data)
     const groupedLocationData = utils.groupBy(data.revenue_summary, 'location')
 
-    nationwideSummary = d3.nest()
-      .key(k => k.location_name)
-      .rollup(v => d3.sum(v, i => i.total))
-      .entries(groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS])
-      .map(d => {
-        return ({ location_name: d.key, total: d.value })
-      })
+    if (groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS] && groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS].length > 0) {
+      nationwideSummary = d3.nest()
+        .key(k => k.location_name)
+        .rollup(v => d3.sum(v, i => i.total))
+        .entries(groupedLocationData[DFC.NATIONWIDE_FEDERAL_FIPS])
+        .map(d => {
+          return ({ location_name: d.key, total: d.value })
+        })
+    }
+    else {
+      nationwideSummary = [{ location: DFC.NATIONWIDE_FEDERAL_FIPS, total: 0 }]
+    }
 
-    nativeSummary = d3.nest()
-      .key(k => k.location_name)
-      .rollup(v => d3.sum(v, i => i.total))
-      .entries(groupedLocationData[DFC.NATIVE_AMERICAN_FIPS])
-      .map(d => {
-        return ({ location_name: d.key, total: d.value })
-      })
+    if (groupedLocationData[DFC.NATIVE_AMERICAN_FIPS] && groupedLocationData[DFC.NATIVE_AMERICAN_FIPS].length > 0) {
+      nativeSummary = d3.nest()
+        .key(k => k.location_name)
+        .rollup(v => d3.sum(v, i => i.total))
+        .entries(groupedLocationData[DFC.NATIVE_AMERICAN_FIPS])
+        .map(d => {
+          return ({ location_name: d.key, total: d.value })
+        })
+    }
+    else {
+      nativeSummary.total = [{ location: DFC.NATIVE_AMERICAN_FIPS, total: 0 }]
+    }
 
     return (
       <>


### PR DESCRIPTION
…or page some it produced erronous data in product location total

Fixes #868

[:sunglasses: PREVIEW](https://868-nulldataerror.app.cloud.gov/explore/)

Changes proposed in this pull request:


There was some logic that was swapping Native American and Nationwide data in 
productionLocationTotals

Jerome can you review logic in Revneu and Disbursements it's different but I think it should be the same.


-
-
-