### PR TITLE
Fixed bad logic array length > 1 instead of > 0

### DIFF
--- a/src/components/sections/ExploreData/Revenue/RevenueSummaryTrends.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueSummaryTrends.js
@@ -123,8 +123,7 @@ const RevenueSummaryTrends = props => {
       x => x[0] === parseInt(year)
     )
 
-    row = fiscalData.length > 1 && fiscalData[fiscalData.findIndex(x => x[0] === parseInt(year))]
-
+    row = fiscalData.length > 0 && fiscalData[fiscalData.findIndex(x => x[0] === parseInt(year))]
     total = row ? row[1] : 0
 
     return (


### PR DESCRIPTION
Fixes #866 

[:sunglasses: PREVIEW](https://866-DataIssueSummaryTrend.app.cloud.gov/explore/)

Changes proposed in this pull request:
Fixed 0 issue in Revenue for timeseries with exactly 1 value. 
-
-
-