### PR TITLE
Fix for duplicate data in detail cards

### DIFF
--- a/src/components/data-viz/StackedBarChart/D3StackedBarChart.js
+++ b/src/components/data-viz/StackedBarChart/D3StackedBarChart.js
@@ -1411,7 +1411,6 @@ export default class D3StackedBarChart {
       .attr('width', this._width)
       .attr('x', 0)
   }
-
 }
 
 /**

--- a/src/components/sections/ExploreData/DetailCards.js
+++ b/src/components/sections/ExploreData/DetailCards.js
@@ -394,12 +394,7 @@ const DetailCards = props => {
       cards.filter(item => item.fipsCode === fips).length === 0
     ) {
       if (cards.length <= MAX_CARDS) {
-        if (stateObj.state && stateObj.state.match(/Nationwide Federal/)) {
-          cards.unshift(stateObj)
-        }
-        else {
-          cards.push(stateObj)
-        }
+        cards.push(stateObj)
       }
       else {
         // TODO: snackbar not triggering atm

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -449,12 +449,7 @@ const MapContext = props => {
       cards.filter(item => item.fipsCode === fips).length === 0
     ) {
       if (cards.length <= MAX_CARDS) {
-        if (stateObj.state && stateObj.state.match(/Nationwide Federal/)) {
-          cards.unshift(stateObj)
-        }
-        else {
-          cards.push(stateObj)
-        }
+        cards.push(stateObj)
       }
       else {
         // TODO: snackbar not triggering atm

--- a/src/components/sections/ExploreData/Revenue/RevenueDetailCommodities.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueDetailCommodities.js
@@ -21,7 +21,6 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     justifyContent: 'flex-start',
     '& .chart-container': {
-      // display: 'grid',
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'top',
@@ -55,12 +54,9 @@ const RevenueDetailCommodities = props => {
   const commodities = (filterState[DFC.COMMODITY]) ? filterState[DFC.COMMODITY].split(',') : undefined
 
   const dataSet = (period === DFC.FISCAL_YEAR_LABEL) ? `FY ${ year }` : `CY ${ year }`
-  const dataKey = dataSet + '-' + state + (filterState[DFC.COMMODITY]) ? filterState[DFC.COMMODITY] : 'ALL'
+  const dataKey = `${ dataSet }-${ state }`
 
   const isCounty = state && state.length === 5
-  // const isNativeAmerican = state && state === DFC.NATIVE_AMERICAN_FIPS
-  // const isNationwideFederal = state && state === DFC.NATIONWIDE_FEDERAL_FIPS
-  // const isState = state && state.length === 2 && !isNativeAmerican && !isNationwideFederal
 
   const { loading, error, data } = useQuery(APOLLO_QUERY, {
     variables: { year: year, state: state, period: period, commodities }

--- a/src/components/sections/TotalProduction/TotalProduction.js
+++ b/src/components/sections/TotalProduction/TotalProduction.js
@@ -85,7 +85,6 @@ const TotalProduction = props => {
   const [selected, setSelected] = useState(undefined)
 
   const toggleChange = value => {
-
     setSelected(undefined)
     setToggle(value)
 


### PR DESCRIPTION
Fixes #957

[:sunglasses: PREVIEW](https://957-duplicatedatacards.app.cloud.gov/explore/)

Changes proposed in this pull request:

- updates to RDC dataKey
- remove unshift of NF card from cards array
-