### PR TITLE
Color card headers

### DIFF
--- a/src/components/data-viz/CircleChart/CircleChart.js
+++ b/src/components/data-viz/CircleChart/CircleChart.js
@@ -100,7 +100,7 @@ const CircleChart = props => {
 
   const { data, ...options } = props
   const elemRef = useRef(null)
-  // console.debug("CLASSES : x", classes)
+
   useEffect(() => {
     elemRef.current.children[0].innerHTML = ''
     elemRef.current.children[1].innerHTML = ''

--- a/src/components/data-viz/CircleChart/CircleChart.js
+++ b/src/components/data-viz/CircleChart/CircleChart.js
@@ -43,6 +43,9 @@ const useStyles = makeStyles((theme, props) => ({
     '& .tooltip': {
       pointerEvents: 'none',
     },
+    '& > svg': {
+      maxWidth: '100%',
+    }
   },
   legend: {
     display: 'block',

--- a/src/components/data-viz/LineChart/LineChart.js
+++ b/src/components/data-viz/LineChart/LineChart.js
@@ -19,16 +19,16 @@ const useStyles = makeStyles(theme => ({
     height: '200px',
     fill: theme.palette.chart.primary,
     '& g path.line:nth-of-type(1)': {
-      stroke: theme.palette.blue[300],
+      stroke: theme.palette.circleChart[400],
     },
     '& g path.line:nth-of-type(2)': {
-      stroke: theme.palette.orange[300],
+      stroke: theme.palette.circleChart[300],
     },
     '& g path.line:nth-of-type(3)': {
-      stroke: theme.palette.green[300],
+      stroke: theme.palette.circleChart[200],
     },
     '& g path.line:nth-of-type(4)': {
-      stroke: theme.palette.purple[300],
+      stroke: theme.palette.circleChart[100],
     }
   },
   legend: {

--- a/src/components/navigation/PageToc/PageToc.js
+++ b/src/components/navigation/PageToc/PageToc.js
@@ -27,7 +27,7 @@ const TOC_DISPLAY_AS_ATTRB = 'data-toc-display-as'
 const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
-    maxWidth: 360,
+    // maxWidth: 360,
     paddingRight: theme.spacing(2),
     paddingTop: theme.spacing(2),
     fontSize: '1.1rem',
@@ -43,12 +43,21 @@ const useStyles = makeStyles(theme => ({
     },
     '& a': {
       color: theme.palette.common.black
-    }
+    },
+    '@media (max-width: 599px)': {
+      paddingRight: 0,
+    },
+    '@media (max-width: 700px) and (min-width: 600px)': {
+      fontSize: '.85rem',
+    },
   },
   tocContainer: {
     padding: theme.spacing(2),
     marginRight: theme.spacing(2),
-    backgroundColor: 'white'
+    backgroundColor: 'white',
+    '@media (max-width: 599px)': {
+      marginRight: 0,
+    }
   },
   tocItem: {
     '& a': {
@@ -61,12 +70,15 @@ const useStyles = makeStyles(theme => ({
     '& a': {
       color: '#323c42',
       fontSize: '1rem',
-      lineHeight: '1.2'
+      lineHeight: '1.2',
+      '@media (max-width: 700px) and (min-width: 600px)': {
+        fontSize: '.85rem',
+      },
     },
     '& li': {
       paddingTop: theme.spacing(0.5),
       paddingBottom: theme.spacing(0.5)
-    }
+    },
   },
   tocItemActive: {
     fontWeight: 'bold',
@@ -106,10 +118,10 @@ const useStyles = makeStyles(theme => ({
       maxWidth: '100%',
       padding: theme.spacing(0)
     },
-    tocContainer: {
-      marginRight: theme.spacing(0),
-      maxWidth: '100%'
-    }
+    // tocContainer: {
+    //   marginRight: theme.spacing(0),
+    //   maxWidth: '100%'
+    // }
   }
 }))
 
@@ -237,7 +249,7 @@ const PageToc = props => {
 
     setToc({
       ...toc,
-      mobileActive: document.documentElement.clientWidth <= 767
+      mobileActive: document.documentElement.clientWidth <= 600
     })
   }
 
@@ -245,7 +257,7 @@ const PageToc = props => {
     <div className={classes.root}>
       <StickyWrapper bottomBoundary={props.bottomBoundary} innerZ="1000">
         <Paper className={classes.tocContainer}>
-          <Hidden mdDown>
+          <Hidden smDown>
             {toc.displayTitle ? (
               <h3 className={classes.displayTitle + ' state-page-nav-title'}>
                 {toc.displayTitle}

--- a/src/components/sections/ExploreData/AddLocationCard.js
+++ b/src/components/sections/ExploreData/AddLocationCard.js
@@ -51,7 +51,7 @@ const useStyles = makeStyles(theme => ({
   },
   cardHeader: {
     padding: 10,
-    height: 75,
+    height: 80,
     fontSize: '1.2rem',
     '& .MuiCardHeader-action': {
       marginTop: 0,

--- a/src/components/sections/ExploreData/DetailCards.js
+++ b/src/components/sections/ExploreData/DetailCards.js
@@ -137,7 +137,7 @@ const useStyles = makeStyles(theme => ({
   root: {
     maxWidth: '25%',
     width: '100%',
-    margin: theme.spacing(1),
+    // margin: theme.spacing(1),
     '@media (max-width: 768px)': {
       maxWidth: '100%',
     },
@@ -153,7 +153,7 @@ const useStyles = makeStyles(theme => ({
   },
   compareCards: {
     display: 'flex',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
     alignItems: 'stretch',
     marginTop: theme.spacing(5),
     padding: 5,
@@ -162,8 +162,11 @@ const useStyles = makeStyles(theme => ({
       display: 'relative',
     },
     '& > div': {
-      margin: 0,
+      marginRight: 10,
       maxWidth: 300,
+    },
+    '& > div:last-child': {
+      margin: 0,
     },
     '& .card-content-container': {
       display: 'flex',

--- a/src/components/sections/ExploreData/DetailCards.js
+++ b/src/components/sections/ExploreData/DetailCards.js
@@ -177,6 +177,18 @@ const useStyles = makeStyles(theme => ({
     },
     '& .card-content-container > div:nth-child(3) .chart-container .legend': {
       minHeight: 245
+    },
+    '& > div:first-child $cardHeader': {
+      backgroundColor: theme.palette.blue[300],
+    },
+    '& > div:nth-child(2) $cardHeader': {
+      backgroundColor: theme.palette.orange[300],
+    },
+    '& > div:nth-child(3) $cardHeader': {
+      backgroundColor: theme.palette.green[300],
+    },
+    '& > div:last-child $cardHeader': {
+      backgroundColor: theme.palette.purple[300],
     }
   },
   closeIcon: {
@@ -193,6 +205,7 @@ const useStyles = makeStyles(theme => ({
     padding: 10,
     height: 75,
     fontSize: '1.2rem',
+    fontWeight: 'bold',
     alignItems: 'center',
     '& .MuiCardHeader-action': {
       marginTop: 0,

--- a/src/components/sections/ExploreData/DetailCards.js
+++ b/src/components/sections/ExploreData/DetailCards.js
@@ -179,16 +179,16 @@ const useStyles = makeStyles(theme => ({
       minHeight: 245
     },
     '& > div:first-child $cardHeader': {
-      borderBottom: `7px solid ${ theme.palette.blue[300] }`,
+      borderBottom: `8px solid ${ theme.palette.circleChart[400] }`,
     },
     '& > div:nth-child(2) $cardHeader': {
-      borderBottom: `7px solid ${ theme.palette.orange[300] }`,
+      borderBottom: `8px solid ${ theme.palette.circleChart[300] }`,
     },
     '& > div:nth-child(3) $cardHeader': {
-      borderBottom: `7px solid ${ theme.palette.green[300] }`,
+      borderBottom: `8px solid ${ theme.palette.circleChart[200] }`,
     },
     '& > div:last-child $cardHeader': {
-      borderBottom: `7px solid ${ theme.palette.purple[300] }`,
+      borderBottom: `8px solid ${ theme.palette.circleChart[100] }`,
     }
   },
   closeIcon: {
@@ -203,7 +203,7 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.primary.dark,
     color: theme.palette.common.white,
     padding: 10,
-    height: 85,
+    height: 80,
     fontSize: '1.2rem',
     fontWeight: 'bold',
     alignItems: 'center',

--- a/src/components/sections/ExploreData/DetailCards.js
+++ b/src/components/sections/ExploreData/DetailCards.js
@@ -153,25 +153,17 @@ const useStyles = makeStyles(theme => ({
   },
   compareCards: {
     display: 'flex',
-    justifyContent: 'flex-start',
+    justifyContent: 'space-between',
     alignItems: 'stretch',
     marginTop: theme.spacing(5),
+    padding: 5,
     overflow: 'auto',
     '& media (max-width: 768px)': {
       display: 'relative',
     },
     '& > div': {
-      marginRight: theme.spacing(1),
-      minWidth: 275,
-    },
-    '& > div:last-child': {
-      margin: theme.spacing(1),
-      maxWidth: '25%',
-      width: '100%',
-      minWidth: 275,
-      '@media (max-width: 768px)': {
-        maxWidth: '100%',
-      }
+      margin: 0,
+      maxWidth: 300,
     },
     '& .card-content-container': {
       display: 'flex',

--- a/src/components/sections/ExploreData/DetailCards.js
+++ b/src/components/sections/ExploreData/DetailCards.js
@@ -179,16 +179,16 @@ const useStyles = makeStyles(theme => ({
       minHeight: 245
     },
     '& > div:first-child $cardHeader': {
-      backgroundColor: theme.palette.blue[300],
+      borderBottom: `7px solid ${ theme.palette.blue[300] }`,
     },
     '& > div:nth-child(2) $cardHeader': {
-      backgroundColor: theme.palette.orange[300],
+      borderBottom: `7px solid ${ theme.palette.orange[300] }`,
     },
     '& > div:nth-child(3) $cardHeader': {
-      backgroundColor: theme.palette.green[300],
+      borderBottom: `7px solid ${ theme.palette.green[300] }`,
     },
     '& > div:last-child $cardHeader': {
-      backgroundColor: theme.palette.purple[300],
+      borderBottom: `7px solid ${ theme.palette.purple[300] }`,
     }
   },
   closeIcon: {
@@ -203,7 +203,7 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.primary.dark,
     color: theme.palette.common.white,
     padding: 10,
-    height: 75,
+    height: 85,
     fontSize: '1.2rem',
     fontWeight: 'bold',
     alignItems: 'center',

--- a/src/components/sections/ExploreData/Disbursements/DisbursementRecipients.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementRecipients.js
@@ -23,7 +23,6 @@ const useStyles = makeStyles(theme => ({
     '& .chart-container': {
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'top',
       '& .chart': {
         width: '100%',
         height: 250

--- a/src/components/sections/ExploreData/Disbursements/DisbursementSources.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementSources.js
@@ -22,7 +22,6 @@ const useStyles = makeStyles(theme => ({
     '& .chart-container': {
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'top',
       '& .chart': {
         width: '100%',
         height: 250

--- a/src/components/sections/ExploreData/Disbursements/DisbursementSources.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementSources.js
@@ -88,8 +88,8 @@ const DisbursementSources = props => {
                 return utils.formatToDollarInt(d)
               }
               }
-              minColor={theme.palette.blue[100]}
-              maxColor={theme.palette.blue[600]}
+              minColor={theme.palette.circleChart[100]}
+              maxColor={theme.palette.circleChart[600]}
               circleTooltip={
                 d => {
                   const r = []

--- a/src/components/sections/ExploreData/Disbursements/DisbursementTopRecipients.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementTopRecipients.js
@@ -59,7 +59,6 @@ const useStyles = makeStyles(theme => ({
   topRecipientChart: {
     '& .chart-container': {
       display: 'flex',
-      // alignItems: 'top',
       '@media (max-width: 426px)': {
         display: 'block',
         margin: 0,

--- a/src/components/sections/ExploreData/Disbursements/DisbursementsOverTime.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementsOverTime.js
@@ -70,16 +70,16 @@ const useStyles = makeStyles(theme => ({
   },
   chipContainer: {
     '& .MuiChip-root:nth-child(1) .line': {
-      stroke: theme.palette.blue[300],
+      stroke: theme.palette.circleChart[400],
     },
     '& .MuiChip-root:nth-child(2) .line': {
-      stroke: theme.palette.orange[300],
+      stroke: theme.palette.circleChart[300],
     },
     '& .MuiChip-root:nth-child(3) .line': {
-      stroke: theme.palette.green[300],
+      stroke: theme.palette.circleChart[200],
     },
     '& .MuiChip-root:nth-child(4) .line': {
-      stroke: theme.palette.purple[300],
+      stroke: theme.palette.circleChart[100],
     }
   }
 }))
@@ -137,7 +137,7 @@ const DisbursementsOverTime = props => {
           <LineChart
             key={'DOT' }
             data={chartData}
-            chartColors={[theme.palette.blue[300], theme.palette.orange[300], theme.palette.green[300], theme.palette.purple[300]]}
+            chartColors={[theme.palette.circleChart[400], theme.palette.circleChart[300], theme.palette.circleChart[200], theme.palette.circleChart[100]]}
             lineDashes={LINE_DASHES}
             lineTooltip={
               (d, i) => {

--- a/src/components/sections/ExploreData/Disbursements/DisbursementsOverTime.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementsOverTime.js
@@ -93,8 +93,8 @@ const DisbursementsOverTime = props => {
   const cards = pageState.cards
 
   const { loading, error, data } = useQuery(APOLLO_QUERY)
-  const handleDelete = props.handleDelete || ((e, val) => {
-    updateExploreDataCards({ ...pageState, cards: cards.filter(item => item.fips !== val) })
+  const handleDelete = props.handleDelete || ((e, fips) => {
+    updateExploreDataCards({ ...pageState, cards: cards.filter(item => item.fipsCode !== fips) })
   })
 
   if (loading) {

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -129,7 +129,7 @@ const useStyles = makeStyles(theme => ({
       }
     },
     '& > div:first-child > .summary-card-header': {
-      backgroundColor: theme.palette.blue[300],
+      borderBottom: `7px solid ${ theme.palette.blue[300] }`,
     },
     '& > div:nth-child(2)': {
       transform: 'translate3d(-10%, 0px, 0px) !important',
@@ -137,7 +137,7 @@ const useStyles = makeStyles(theme => ({
         transform: 'none !important',
       },
       '& > .summary-card-header': {
-        backgroundColor: theme.palette.orange[300],
+        borderBottom: `7px solid ${ theme.palette.orange[300] }`,
       },
     },
     '& > div:nth-child(3)': {
@@ -146,7 +146,7 @@ const useStyles = makeStyles(theme => ({
         transform: 'none !important',
       },
       '& > .summary-card-header': {
-        backgroundColor: theme.palette.green[300],
+        borderBottom: `7px solid ${ theme.palette.green[300] }`,
       },
     },
     '& > div:last-child': {
@@ -155,7 +155,7 @@ const useStyles = makeStyles(theme => ({
         transform: 'none !important',
       },
       '& > .summary-card-header': {
-        backgroundColor: theme.palette.purple[300],
+        borderBottom: `7px solid ${ theme.palette.purple[300] }`,
       },
     },
     '& .minimized ~ div:nth-of-type(2)': {

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -149,7 +149,7 @@ const useStyles = makeStyles(theme => ({
         borderBottom: `8px solid ${ theme.palette.circleChart[200] }`,
       },
     },
-    '& > div:last-child': {
+    '& > div:nth-child(4)': {
       transform: 'translate3d(-30%, 0px, 0px) !important',
       '@media (max-width: 768px)': {
         transform: 'none !important',

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -129,7 +129,7 @@ const useStyles = makeStyles(theme => ({
       }
     },
     '& > div:first-child > .summary-card-header': {
-      borderBottom: `7px solid ${ theme.palette.blue[300] }`,
+      borderBottom: `8px solid ${ theme.palette.circleChart[400] }`,
     },
     '& > div:nth-child(2)': {
       transform: 'translate3d(-10%, 0px, 0px) !important',
@@ -137,7 +137,7 @@ const useStyles = makeStyles(theme => ({
         transform: 'none !important',
       },
       '& > .summary-card-header': {
-        borderBottom: `7px solid ${ theme.palette.orange[300] }`,
+        borderBottom: `8px solid ${ theme.palette.circleChart[300] }`,
       },
     },
     '& > div:nth-child(3)': {
@@ -146,7 +146,7 @@ const useStyles = makeStyles(theme => ({
         transform: 'none !important',
       },
       '& > .summary-card-header': {
-        borderBottom: `7px solid ${ theme.palette.green[300] }`,
+        borderBottom: `8px solid ${ theme.palette.circleChart[200] }`,
       },
     },
     '& > div:last-child': {
@@ -155,7 +155,7 @@ const useStyles = makeStyles(theme => ({
         transform: 'none !important',
       },
       '& > .summary-card-header': {
-        borderBottom: `7px solid ${ theme.palette.purple[300] }`,
+        borderBottom: `8px solid ${ theme.palette.circleChart[100] }`,
       },
     },
     '& .minimized ~ div:nth-of-type(2)': {

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -126,12 +126,18 @@ const useStyles = makeStyles(theme => ({
         minWidth: 285,
         minHeight: 340,
         marginBottom: theme.spacing(1),
-      },
+      }
+    },
+    '& > div:first-child > .summary-card-header': {
+      backgroundColor: theme.palette.blue[300],
     },
     '& > div:nth-child(2)': {
       transform: 'translate3d(-10%, 0px, 0px) !important',
       '@media (max-width: 768px)': {
         transform: 'none !important',
+      },
+      '& > .summary-card-header': {
+        backgroundColor: theme.palette.orange[300],
       },
     },
     '& > div:nth-child(3)': {
@@ -139,17 +145,17 @@ const useStyles = makeStyles(theme => ({
       '@media (max-width: 768px)': {
         transform: 'none !important',
       },
+      '& > .summary-card-header': {
+        backgroundColor: theme.palette.green[300],
+      },
     },
-    '& > div:nth-child(4)': {
+    '& > div:last-child': {
       transform: 'translate3d(-30%, 0px, 0px) !important',
       '@media (max-width: 768px)': {
         transform: 'none !important',
       },
-    },
-    '& > div:nth-child(5)': {
-      transform: 'translate3d(-40%, 0px, 0px) !important',
-      '@media (max-width: 768px)': {
-        transform: 'none !important',
+      '& > .summary-card-header': {
+        backgroundColor: theme.palette.purple[300],
       },
     },
     '& .minimized ~ div:nth-of-type(2)': {
@@ -160,9 +166,6 @@ const useStyles = makeStyles(theme => ({
     },
     '& .minimized ~ div:nth-of-type(4)': {
       transform: 'translate3d(-20%, 0px, 0px) !important',
-    },
-    '& .minimized ~ div:nth-of-type(5)': {
-      transform: 'translate3d(-30%, 0px, 0px) !important',
     },
     '@media (min-width: 769px)': {
       '&:hover': {
@@ -176,9 +179,6 @@ const useStyles = makeStyles(theme => ({
         '& > div:nth-child(4)': {
           transform: 'translate3d(-300%, 0px, 0px) !important',
         },
-        '& > div:nth-child(5)': {
-          transform: 'translate3d(-400%, 0px, 0px) !important',
-        },
         '& .minimized ~ div:nth-of-type(2)': {
           transform: 'translate3d(0px, 0px, 0px) !important',
         },
@@ -187,9 +187,6 @@ const useStyles = makeStyles(theme => ({
         },
         '& .minimized ~ div:nth-of-type(4)': {
           transform: 'translate3d(-200%, 0px, 0px) !important',
-        },
-        '& .minimized ~ div:nth-of-type(5)': {
-          transform: 'translate3d(-300%, 0px, 0px) !important',
         },
       }
     }

--- a/src/components/sections/ExploreData/Production/ProductionCountyMap.js
+++ b/src/components/sections/ExploreData/Production/ProductionCountyMap.js
@@ -18,7 +18,6 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'flex-start',
-    alignItems: 'top',
     '& .mapContainer': {
       height: 100,
       width: 245,

--- a/src/components/sections/ExploreData/Production/ProductionLandCategory.js
+++ b/src/components/sections/ExploreData/Production/ProductionLandCategory.js
@@ -154,7 +154,7 @@ const ProductionLandCategory = ({ title, ...props }) => {
             <LineChart
               key={'PLC' + dataSet + period + commodity}
               data={chartData}
-              chartColors={[theme.palette.blue[300], theme.palette.orange[300], theme.palette.green[300], theme.palette.purple[300]]}
+              chartColors={[theme.palette.circleChart[400], theme.palette.circleChart[300], theme.palette.circleChart[200], theme.palette.circleChart[100]]}
               lineDashes={LINE_DASHES}
               lineTooltip={
                 (d, i) => {

--- a/src/components/sections/ExploreData/Production/ProductionOverTime.js
+++ b/src/components/sections/ExploreData/Production/ProductionOverTime.js
@@ -98,8 +98,8 @@ const ProductionOverTime = props => {
     variables: { product: product, period: period }
   })
 
-  const handleDelete = props.handleDelete || ((e, val) => {
-    updateExploreDataCards({ ...pageState, cards: cards.filter(item => item.fipsCode !== val) })
+  const handleDelete = props.handleDelete || ((e, fips) => {
+    updateExploreDataCards({ ...pageState, cards: cards.filter(item => item.fipsCode !== fips) })
   })
 
   if (loading) {

--- a/src/components/sections/ExploreData/Production/ProductionOverTime.js
+++ b/src/components/sections/ExploreData/Production/ProductionOverTime.js
@@ -70,16 +70,16 @@ const useStyles = makeStyles(theme => ({
   },
   chipContainer: {
     '& .MuiChip-root:nth-child(1) .line': {
-      stroke: theme.palette.blue[300],
+      stroke: theme.palette.circleChart[400],
     },
     '& .MuiChip-root:nth-child(2) .line': {
-      stroke: theme.palette.orange[300],
+      stroke: theme.palette.circleChart[300],
     },
     '& .MuiChip-root:nth-child(3) .line': {
-      stroke: theme.palette.green[300],
+      stroke: theme.palette.circleChart[200],
     },
     '& .MuiChip-root:nth-child(4) .line': {
-      stroke: theme.palette.purple[300],
+      stroke: theme.palette.circleChart[100],
     }
   }
 }))
@@ -155,7 +155,7 @@ const ProductionOverTime = props => {
           <LineChart
             key={'POT' + period + cards.length + product }
             data={chartData}
-            chartColors={[theme.palette.blue[300], theme.palette.orange[300], theme.palette.green[300], theme.palette.purple[300]]}
+            chartColors={[theme.palette.circleChart[400], theme.palette.circleChart[300], theme.palette.circleChart[200], theme.palette.circleChart[100]]}
             lineDashes={LINE_DASHES}
             lineTooltip={
               (d, i) => {

--- a/src/components/sections/ExploreData/Production/ProductionTopLocations.js
+++ b/src/components/sections/ExploreData/Production/ProductionTopLocations.js
@@ -89,7 +89,6 @@ const useStyles = makeStyles(theme => ({
   chartHorizontal: {
     '& .chart-container': {
       display: 'flex',
-      // alignItems: 'top',
       '@media (max-width: 426px)': {
         display: 'block',
         margin: 0,

--- a/src/components/sections/ExploreData/Revenue/RevenueCountyMap.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueCountyMap.js
@@ -19,7 +19,6 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'flex-start',
-    alignItems: 'top',
     '& .mapContainer': {
       height: 100,
       width: '100%',

--- a/src/components/sections/ExploreData/Revenue/RevenueDetailCommodities.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueDetailCommodities.js
@@ -23,7 +23,6 @@ const useStyles = makeStyles(theme => ({
     '& .chart-container': {
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'top',
     },
   }
 }))

--- a/src/components/sections/ExploreData/Revenue/RevenueDetailTypes.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueDetailTypes.js
@@ -22,10 +22,8 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     justifyContent: 'flex-start',
     '& .chart-container': {
-      // display: 'grid',
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'top',
     }
   }
 }))

--- a/src/components/sections/ExploreData/Revenue/RevenueOverTime.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueOverTime.js
@@ -65,16 +65,16 @@ const useStyles = makeStyles(theme => ({
   },
   chipContainer: {
     '& .MuiChip-root:nth-child(1) .line': {
-      stroke: theme.palette.blue[300],
+      stroke: theme.palette.circleChart[400],
     },
     '& .MuiChip-root:nth-child(2) .line': {
-      stroke: theme.palette.orange[300],
+      stroke: theme.palette.circleChart[300],
     },
     '& .MuiChip-root:nth-child(3) .line': {
-      stroke: theme.palette.green[300],
+      stroke: theme.palette.circleChart[200],
     },
     '& .MuiChip-root:nth-child(4) .line': {
-      stroke: theme.palette.purple[300],
+      stroke: theme.palette.circleChart[100],
     }
   }
 }))
@@ -145,7 +145,7 @@ const RevenueOverTime = props => {
           <LineChart
             key={'ROT' + commodityKey + period}
             data={chartData}
-            chartColors={[theme.palette.blue[300], theme.palette.orange[300], theme.palette.green[300], theme.palette.purple[300]]}
+            chartColors={[theme.palette.circleChart[400], theme.palette.circleChart[300], theme.palette.circleChart[200], theme.palette.circleChart[100]]}
             lineDashes={LINE_DASHES}
             lineTooltip={
               (d, i) => {

--- a/src/components/sections/ExploreData/Revenue/RevenueOverTime.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueOverTime.js
@@ -82,6 +82,7 @@ const useStyles = makeStyles(theme => ({
 const RevenueOverTime = props => {
   const classes = useStyles()
   const theme = useTheme()
+  console.log('RevenueOverTime theme: ', theme)
   const title = props.title || ''
   const { state: filterState } = useContext(DataFilterContext)
   const { state: pageState, updateExploreDataCards } = useContext(ExploreDataContext)
@@ -94,8 +95,8 @@ const RevenueOverTime = props => {
     variables: { period: period, commodities: commodities }
   })
 
-  const handleDelete = props.handleDelete || ((e, val) => {
-    updateExploreDataCards({ ...pageState, cards: cards })
+  const handleDelete = props.handleDelete || ((e, fips) => {
+    updateExploreDataCards({ ...pageState, cards: cards.filter(item => item.fipsCode !== fips) })
   })
 
   if (loading) {

--- a/src/components/sections/ExploreData/Revenue/RevenueTopLocations.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueTopLocations.js
@@ -61,7 +61,6 @@ const useStyles = makeStyles(theme => ({
   topLocationsChart: {
     '& .chart-container': {
       display: 'flex',
-      // alignItems: 'top',
       '@media (max-width: 426px)': {
         display: 'block',
         margin: 0,

--- a/src/components/sections/ExploreData/SummaryCards.js
+++ b/src/components/sections/ExploreData/SummaryCards.js
@@ -31,7 +31,7 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     right: 0,
     transform: 'translate3d(0, 0px, 0px)',
-    minHeight: 340,
+    minHeight: 350,
     '@media (max-width: 768px)': {
       width: '100%',
       height: 'auto',

--- a/src/components/sections/ExploreData/SummaryCards.js
+++ b/src/components/sections/ExploreData/SummaryCards.js
@@ -169,6 +169,7 @@ const SummaryCards = props => {
             }
             classes={{ root: classes.cardHeader, content: classes.cardHeaderContent }}
             disableTypography
+            className="summary-card-header"
           >
             <Typography variant="h4" color="inherit">
               {props.name}

--- a/src/components/sections/ExploreData/SummaryCards.js
+++ b/src/components/sections/ExploreData/SummaryCards.js
@@ -50,7 +50,7 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.primary.dark,
     color: theme.palette.common.white,
     padding: 10,
-    height: 45,
+    height: 55,
     fontSize: '1.2rem',
     '& .MuiCardHeader-action': {
       marginTop: 0,

--- a/src/components/utils/PercentDifference/PercentDifference.js
+++ b/src/components/utils/PercentDifference/PercentDifference.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles(theme => ({
     marginRight: 5,
     top: 3,
     fontSize: 'large',
-    color: theme.palette.orange[200],
+    color: theme.palette.orange[300],
   },
 }))
 

--- a/src/js/mui/palette.js
+++ b/src/js/mui/palette.js
@@ -14,6 +14,14 @@ module.exports = Object.freeze({
     primary: '#222222',
     secondary: '#43646F'
   },
+  circleChart: {
+    100: '#c4d99b',
+    200: '#c1ab76',
+    300: '#af7f63',
+    400: '#8f5a59',
+    500: '#653d4e',
+    600: '#37253c'
+  },
   links: {
     default: '#1478a6',
     hover: '#126991',

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -16,7 +16,7 @@ tags:
 <Container maxWidth="lg">
 <Grid container spacing={2} alignItems='center'>
 <Grid item xs={12} sm={8}>
-<Box p={3}  pl={0}>
+<Box p={3} pl={0}>
 
 # How Revenue Works
 
@@ -26,16 +26,16 @@ Learn what [governs natural resource extraction](#what-laws-regulations-govern-n
 
 </Box>
 </Grid>
-<Grid container xs={12} sm={4} >
+<Grid item xs={12} sm={4} >
 <Box p={3} border={4} borderTop={0} borderBottom={0} borderColor='white'>
-<Grid item xs={12}>
+{/* <Grid item xs={12}> */}
 
 **Natural resource extraction in the U.S. is governed by laws and regulations tied primarily to land ownership and the commodities being extracted.**
 
 <Box align='center'>
-  <HowItWorksRibbonGraphicImg style={{height:'100px'}} alignSelf='center'></HowItWorksRibbonGraphicImg>
+  <HowItWorksRibbonGraphicImg style={{height:'100px', maxWidth: '100%'}} alignSelf='center'></HowItWorksRibbonGraphicImg>
 </Box>
-</Grid>
+{/* </Grid> */}
 </Box>
 </Grid>
 </Grid>


### PR DESCRIPTION
Fixes #329
[:sunglasses: PREVIEW](https://preview-nrrd.app.cloud.gov/explore?dataType=Revenue&location=NF%2CNA%2CMT%2CCA&mapLevel=State&offshoreRegions=false&period=Fiscal%20Year&year=2019)

Changes proposed in this pull request:

- adds color to card headers to match line chart
-
-