### PR TITLE
add space in explore data disbursements summary

### DIFF
--- a/src/components/sections/ExploreData/Disbursements/DisbursementLocationTotal.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementLocationTotal.js
@@ -66,8 +66,7 @@ const DisbursementLocationTotal = props => {
       <>
         After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue (ONRR) distributes that money to different agencies,
         funds, and local governments for public use. This process is called "disbursement." <strong>In {period.toLowerCase()} {year},
-        ONRR disbursed {utils.formatToDollarInt(nationwideSummary[0].total)} from federal sources and {utils.formatToDollarInt(nativeSummary[0].total)}
-        from Native American sources for a total of {utils.formatToDollarInt(nationwideSummary[0].total + nativeSummary[0].total)}</strong>.
+        ONRR disbursed {utils.formatToDollarInt(nationwideSummary[0].total)} from federal sources and {utils.formatToDollarInt(nativeSummary[0].total)} from Native American sources for a total of {utils.formatToDollarInt(nationwideSummary[0].total + nativeSummary[0].total)}</strong>.
       </>
     )
   }


### PR DESCRIPTION
Fixes #1010 
[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1010-add-space/explore/?dataType=Disbursements&mapLevel=State&offshoreRegions=false&period=Fiscal%20Year&year=2019)

Changes proposed in this pull request:
- added space in disbursements summary sentence on explore data
-
-