### PR TITLE
fix to year slider max years, update line chart to get chart data years 

### DIFF
--- a/src/components/data-viz/LineChart/D3LineChart.js
+++ b/src/components/data-viz/LineChart/D3LineChart.js
@@ -106,7 +106,9 @@ export default class D3LineChart {
       const lineDashes = this.lineDashes
       const lineStrokes = this.lineStrokes
       const lineTooltip = this.lineTooltip
-      const x = d3.scaleLinear().domain([2003, 2019]).range([0, width])
+      const years = this.data[0]
+
+      const x = d3.scaleLinear().domain([years[0], years[years.length - 1]]).range([0, width])
       // const y = d3.scaleLinear().domain([0, 40000000]).range([height, 0])
 
       const svg = d3.select(this.chartNode).append('svg')

--- a/src/components/sections/ExploreData/Disbursements/DisbursementLocationTotal.js
+++ b/src/components/sections/ExploreData/Disbursements/DisbursementLocationTotal.js
@@ -68,7 +68,7 @@ const DisbursementLocationTotal = props => {
         After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue (ONRR) distributes that money to different agencies,
         funds, and local governments for public use. This process is called "disbursement." <strong>In {period.toLowerCase()} {year},
         ONRR disbursed {utils.formatToDollarInt(nationwideSummary[0].total)} from federal sources and {utils.formatToDollarInt(nativeSummary[0].total)}
-	from Native American sources for a total of {utils.formatToDollarInt(nationwideSummary[0].total + nativeSummary[0].total)}</strong>.
+	      {' '}from Native American sources for a total of {utils.formatToDollarInt(nationwideSummary[0].total + nativeSummary[0].total)}</strong>.
       </>
     )
   }

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -275,8 +275,6 @@ const MapContext = props => {
   const theme = useTheme()
   const size = useWindowSize()
 
-  console.log('MapContext size: ', size)
-
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'))
   const matchesMdUp = useMediaQuery(theme.breakpoints.up('md'))
 

--- a/src/components/sections/ExploreData/Revenue/RevenueLocationTotal.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueLocationTotal.js
@@ -75,7 +75,7 @@ const RevenueLocationTotal = props => {
       <>
         When companies extract natural resources on federal or Native American lands and waters, they pay royalties, rents, bonuses, and other fees,
         much like they would to any resource owner. The Office of Natural Resources Revenue (ONRR) collects and disburses these revenues.
-        <strong>In {period.toLowerCase()} {year}, ONRR collected {utils.formatToDollarInt(nationwideSummary[0].total)} from federal sources
+        {' '}<strong>In {period.toLowerCase()} {year}, ONRR collected {utils.formatToDollarInt(nationwideSummary[0].total)} from federal sources
         and {utils.formatToDollarInt(nativeSummary[0].total)} from Native American sources for a total of
         {utils.formatToDollarInt(nationwideSummary[0].total + nativeSummary[0].total)}</strong>.
       </>

--- a/src/components/sections/ExploreData/YearSlider.js
+++ b/src/components/sections/ExploreData/YearSlider.js
@@ -18,6 +18,7 @@ const APOLLO_QUERY = gql`
     # period query
     period(where: {period: {_ilike: $period }}) {
       fiscal_year
+      calendar_year
     }
   }
 `
@@ -170,7 +171,7 @@ const YearSlider = props => {
   const customMarks = []
 
   const { loading, error, data } = useQuery(APOLLO_QUERY, {
-    variables: { period: DFC.FISCAL_YEAR_LABEL }
+    variables: { period: (filterState[DFC.DATA_TYPE] === DFC.DISBURSEMENT) ? DFC.FISCAL_YEAR_LABEL : DFC.PERIOD_CALENDAR_YEAR }
   })
 
   if (loading) {}
@@ -180,8 +181,13 @@ const YearSlider = props => {
     periodData = data.period
 
     // set min and max trend years
-    minYear = periodData.reduce((min, p) => p.fiscal_year < min ? p.fiscal_year : min, periodData[0].fiscal_year)
-    maxYear = periodData.reduce((max, p) => p.fiscal_year > max ? p.fiscal_year : max, periodData[periodData.length - 1].fiscal_year)
+    minYear = (filterState[DFC.DATA_TYPE] === DFC.DISBURSEMENT)
+      ? periodData.reduce((min, p) => p.fiscal_year < min ? p.fiscal_year : min, periodData[0].fiscal_year)
+      : periodData.reduce((min, p) => p.calendar_year < min ? p.calendar_year : min, periodData[0].calendar_year)
+    maxYear = (filterState[DFC.DATA_TYPE] === DFC.DISBURSEMENT)
+      ? periodData.reduce((max, p) => p.fiscal_year > max ? p.fiscal_year : max, periodData[periodData.length - 1].fiscal_year)
+      : periodData.reduce((max, p) => p.calendar_year > max ? p.calendar_year : max, periodData[periodData.length - 1].calendar_year)
+
     if (!year) {
       year = maxYear
       handleOnchange(maxYear)

--- a/src/stores/data-filter-store/reducers.js
+++ b/src/stores/data-filter-store/reducers.js
@@ -139,10 +139,10 @@ const initialState = {
         [DATA_TYPE]: DISBURSEMENT,
         [GROUP_BY]: RECIPIENT,
         [PERIOD]: 'Fiscal Year',
-        [FISCAL_YEAR]: '2019',
+        [FISCAL_YEAR]: '2020',
         [OFFSHORE_REGIONS]: false,
         [MAP_LEVEL]: STATE,
-        [YEAR]: 2019,
+        [YEAR]: 2020,
       }
     }
   }


### PR DESCRIPTION
Fixes #1087, #1088

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/2020-FixYearSliderRevenueAndProduction/explore/)

Changes proposed in this pull request:

- fixes year slider for revenue and production 
- fixes for trendline tooltip not showing all years
-