### PR TITLE
Have nationwide card open by default

### DIFF
--- a/src/stores/explore-data-store/reducers.js
+++ b/src/stores/explore-data-store/reducers.js
@@ -26,7 +26,17 @@ const reducer = (state, action) => {
 
 // Explore data initialState
 const initialState = {
-  cards: [],
+  cards: [
+    {
+      fipsCode: 'NF',
+      name: 'Nationwide Federal',
+      locationName: 'Nationwide Federal',
+      state: 'Nationwide Federal',
+      regionType: '',
+      districtType: undefined,
+      county: ''
+    }
+  ],
   mapX: -180,
   mapY: -80,
   mapZoom: 1.25,


### PR DESCRIPTION
Fixes #1047

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1047-OpenNFCardByDefault/explore/)

Changes proposed in this pull request:

- Sets nationwide federal card as default
-
-