### PR TITLE
Make state, county and offshore controls more visible

### DIFF
--- a/src/components/sections/ExploreData/ExploreMoreDataButton.js
+++ b/src/components/sections/ExploreData/ExploreMoreDataButton.js
@@ -42,10 +42,6 @@ const useStyles = makeStyles(theme => ({
     lineHeight: 1.25,
     padding: '5px 16px',
   },
-  buttonScrollLabel: {
-    fontSize: 14,
-    position: 'relative',
-  },
   buttonScrollIcon: {
     height: 20,
     '& svg': {
@@ -116,9 +112,6 @@ const ExploreMoreDataButton = props => {
         onClick={buttonState.icon === 'down' ? scrollTo : scrollToTop}
       >
         {buttonState.label}
-        <span className={classes.buttonScrollLabel}>
-          { buttonState.icon === 'down' ? 'Scroll down' : 'Scroll up' }
-        </span>
         <span className={classes.buttonScrollIcon}>
           {buttonState.icon === 'down' ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
         </span>

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -21,6 +21,7 @@ import {
 
 import { animateScroll as scroll } from 'react-scroll'
 
+import MapLevel from './MapLevel'
 import MapControls from './MapControls'
 import ExploreDataToolbar from '../../toolbars/ExploreDataToolbar'
 
@@ -579,16 +580,14 @@ const MapContext = props => {
     <>
       <ExploreDataToolbar
         onLink={onLink}
-        cardMenuItems={cardMenuItems}
-        mapOverlay={mapOverlay} />
+        cardMenuItems={cardMenuItems} />
       <Container className={classes.mapContextWrapper} maxWidth={false}>
         <Grid container>
           <Grid item xs={12}>
             <Box className={classes.mapWrapper}>
+              <MapLevel mapOverlay={mapOverlay} />
               {mapChild}
-              <MapControls
-                handleClick={handleClick}
-              />
+              <MapControls handleClick={handleClick} />
             </Box>
             <Box className={`map-overlay ${ mapOverlay ? 'active' : '' }`}></Box>
           </Grid>

--- a/src/components/sections/ExploreData/MapControls.js
+++ b/src/components/sections/ExploreData/MapControls.js
@@ -37,6 +37,10 @@ const useStyles = makeStyles(theme => ({
 const MapControls = props => {
   const classes = useStyles()
 
+  const {
+    handleClick,
+  } = props
+
   return (
     <Box className={classes.zoomButtonGroupContainer}>
       <ButtonGroup
@@ -44,13 +48,13 @@ const MapControls = props => {
         variant="contained"
         aria-label="Explore data map zoom controls"
         classes={{ grouped: classes.buttonGroupGrouped }}>
-        <Button onClick={() => props.handleClick('add')} role="button" aria-label="Map zoom in">
+        <Button onClick={() => handleClick('add')} role="button" aria-label="Map zoom in">
           <AddIcon />
         </Button>
-        <Button onClick={() => props.handleClick('remove')} role="button" aria-label="Map zoom out">
+        <Button onClick={() => handleClick('remove')} role="button" aria-label="Map zoom out">
           <RemoveIcon />
         </Button>
-        <Button onClick={() => props.handleClick('refresh')} role="button" aria-label="Map reset">
+        <Button onClick={() => handleClick('refresh')} role="button" aria-label="Map reset">
           <RefreshIcon />
         </Button>
       </ButtonGroup>

--- a/src/components/sections/ExploreData/MapLevel.js
+++ b/src/components/sections/ExploreData/MapLevel.js
@@ -1,0 +1,132 @@
+import React, { useContext, useState } from 'react'
+
+import {
+  Box,
+  Button,
+  Menu,
+  MenuItem
+} from '@material-ui/core'
+
+import { makeStyles } from '@material-ui/core/styles'
+
+import {
+  MapLevelToggleInput,
+  OffshoreRegionsSwitchInput
+} from '../../inputs'
+
+import {
+  DATA_FILTER_CONSTANTS as DFC,
+  OFFSHORE_REGIONS,
+  MAP_LEVEL
+} from '../../../constants'
+
+import { DataFilterContext } from '../../../stores/data-filter-store'
+import { interpolateRgbBasis } from 'd3-interpolate'
+
+const MAP_LEVEL_OPTIONS = {
+  [MAP_LEVEL]: [
+    { value: DFC.STATE, option: DFC.STATE },
+    { value: DFC.COUNTY_CAPITALIZED, option: DFC.COUNTY_CAPITALIZED }
+  ],
+  [OFFSHORE_REGIONS]: [
+    { value: false, option: '' },
+    { value: true, option: '' }
+  ]
+}
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    height: 'auto',
+    '@media and (max-width: 600px)': {
+      top: 5,
+      left: 5,
+    }
+  },
+  mapLevelButton: {
+    background: theme.palette.common.white,
+    color: theme.palette.common.black,
+    '&:hover': {
+      background: theme.palette.common.white,
+    }
+  },
+  menuItem: {
+    '&:hover': {
+      backgroundColor: 'rgba(0,0,0,0)',
+    }
+  }
+}))
+
+const MapLevel = props => {
+  const classes = useStyles()
+
+  const { state: filterState } = useContext(DataFilterContext)
+
+  const {
+    mapOverlay
+  } = props
+
+  const {
+    dataType,
+    mapLevel,
+    offshoreRegions
+  } = filterState
+
+  const secondaryOptionLabel = `${ mapLevel || DFC.STATE } ${ (offshoreRegions === true) ? ' and offshore' : '' }`
+
+  const [anchorEl, setAnchorEl] = useState(null)
+
+  const handleClickListItem = event => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  return (
+    <Box className={classes.root}>
+      <Button
+        variant="contained"
+        aria-haspopup="true"
+        aria-controls="map-level-menu"
+        aria-label="Map level"
+        size="small"
+        onClick={handleClickListItem}
+        className={classes.mapLevelButton}>
+          Map level <strong>&nbsp;{secondaryOptionLabel}</strong>
+      </Button>
+      <Menu
+        id="map-level-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={anchorEl}
+        onClose={handleClose}>
+        <MenuItem key={0} className={classes.menuItem}>
+          <MapLevelToggleInput
+            dataFilterKey={MAP_LEVEL}
+            defaultSelected={mapLevel || DFC.STATE}
+            data={MAP_LEVEL_OPTIONS[MAP_LEVEL]}
+            label="Map level toggle"
+            legend="Map level"
+            size="small"
+            disabled={mapOverlay} />
+        </MenuItem>
+        <MenuItem key={1} className={classes.menuItem}>
+          <OffshoreRegionsSwitchInput
+            dataFilterKey={OFFSHORE_REGIONS}
+            data={MAP_LEVEL_OPTIONS[OFFSHORE_REGIONS]}
+            defaultSelected={offshoreRegions === true}
+            label='Show offshore'
+            helperText='Disbursements from offshore production go to the states and counties that surround the offshore area.'
+            disabled={dataType === 'Disbursements' || mapOverlay}
+            selectType='Single' />
+        </MenuItem>
+      </Menu>
+    </Box>
+  )
+}
+
+export default MapLevel

--- a/src/components/toolbars/ExploreDataToolbar/ExploreDataToolbar.js
+++ b/src/components/toolbars/ExploreDataToolbar/ExploreDataToolbar.js
@@ -26,9 +26,7 @@ import {
   CommoditySelectInput,
   DataTypeSelectInput,
   FilterToggleInput,
-  MapLevelToggleInput,
-  PeriodSelectInput,
-  OffshoreRegionsSwitchInput
+  PeriodSelectInput
 } from '../../inputs'
 
 import YearSlider from '../../sections/ExploreData/YearSlider'
@@ -40,9 +38,7 @@ import {
   DISBURSEMENT,
   PERIOD,
   PRODUCTION,
-  REVENUE,
-  OFFSHORE_REGIONS,
-  MAP_LEVEL
+  REVENUE
 } from '../../../constants'
 
 const EXPLORE_DATA_TOOLBAR_OPTIONS = {
@@ -55,14 +51,6 @@ const EXPLORE_DATA_TOOLBAR_OPTIONS = {
     { value: DFC.FISCAL_YEAR_LABEL, option: DFC.PERIOD_FISCAL_YEAR },
     { value: DFC.PERIOD_CALENDAR_YEAR, option: DFC.PERIOD_CALENDAR_YEAR },
     // { value: DFC.PERIOD_MONTHLY_YEAR, option: DFC.PERIOD_MONTHLY_YEAR }
-  ],
-  [MAP_LEVEL]: [
-    { value: DFC.STATE, option: DFC.STATE },
-    { value: DFC.COUNTY_CAPITALIZED, option: DFC.COUNTY_CAPITALIZED }
-  ],
-  [OFFSHORE_REGIONS]: [
-    { value: false, option: '' },
-    { value: true, option: '' }
   ]
 }
 
@@ -130,8 +118,7 @@ ProductionCommodityOptions: production_commodity_options(where: {product: {_neq:
 
   const {
     onLink,
-    cardMenuItems,
-    mapOverlay
+    cardMenuItems
   } = props
 
   const productionCommodityOptions = data.onrr.ProductionCommodityOptions.map(item => item.product)
@@ -267,27 +254,6 @@ ProductionCommodityOptions: production_commodity_options(where: {product: {_neq:
             }
             <YearSlider />
           </Box>
-          {!mapOverlay &&
-          <Box className={classes.toolsWrapper}>
-            <MapLevelToggleInput
-              dataFilterKey={MAP_LEVEL}
-              defaultSelected={mapLevel || DFC.STATE}
-              data={EXPLORE_DATA_TOOLBAR_OPTIONS[MAP_LEVEL]}
-              label="Map level toggle"
-              legend="Map level"
-              size="small"
-              disabled={mapOverlay} />
-
-            <OffshoreRegionsSwitchInput
-              dataFilterKey={OFFSHORE_REGIONS}
-              data={EXPLORE_DATA_TOOLBAR_OPTIONS[OFFSHORE_REGIONS]}
-              defaultSelected={offshoreRegions === true}
-              label='Show offshore'
-              helperText='Disbursements from offshore production go to the states and counties that surround the offshore area.'
-              disabled={dataType === 'Disbursements' || mapOverlay}
-              selectType='Single' />
-          </Box>
-          }
         </BaseToolbar>
         }
         {locationTabOpen &&


### PR DESCRIPTION
Fixes #1054

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1054-MakCountyOffshoreMoreVisible/explore/)

Changes proposed in this pull request:

- moves state/county and offshore controls down into map
- add MapLevel component to manage map level controls
-