### PR TITLE
Fixed space issue in revenue location total

### DIFF
--- a/src/components/sections/ExploreData/Revenue/RevenueLocationTotal.js
+++ b/src/components/sections/ExploreData/Revenue/RevenueLocationTotal.js
@@ -76,7 +76,7 @@ const RevenueLocationTotal = props => {
         When companies extract natural resources on federal or Native American lands and waters, they pay royalties, rents, bonuses, and other fees,
         much like they would to any resource owner. The Office of Natural Resources Revenue (ONRR) collects and disburses these revenues.
         {' '}<strong>In {period.toLowerCase()} {year}, ONRR collected {utils.formatToDollarInt(nationwideSummary[0].total)} from federal sources
-        and {utils.formatToDollarInt(nativeSummary[0].total)} from Native American sources for a total of
+        and {utils.formatToDollarInt(nativeSummary[0].total)} from Native American sources for a total of{' '}
         {utils.formatToDollarInt(nationwideSummary[0].total + nativeSummary[0].total)}</strong>.
       </>
     )


### PR DESCRIPTION
Fixes #1040 

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1040-RevenueLocationTotalSpacing
Changes proposed in this pull request:

Fixed spacing in revenue explore data page
-
-
-