### PR TITLE
1044 zoom and pan options WIP

### DIFF
--- a/src/components/data-viz/Map/Map.js
+++ b/src/components/data-viz/Map/Map.js
@@ -17,10 +17,10 @@ const useStyles = makeStyles(theme => ({
   root: {
     height: '100%',
     width: '100%',
-      '& .mapContainer': {
-	height: '100%',
-	width: '100%',
-      },
+    '& .mapContainer': {
+      height: '100%',
+      width: '100%',
+    },
     '& .map': {
       height: '100%',
       width: '100%',
@@ -48,7 +48,7 @@ const useStyles = makeStyles(theme => ({
       }
     }
   }
-    
+
 }))
 
 /**
@@ -140,10 +140,10 @@ const Map = props => {
       options
     )
 
-      /* 
+    /*
        * map.onZoom = onZoom
        * map.onZoomEnd = onZoomEnd
-       * 
+       *
        * if (!isNaN(mapX) && !isNaN(mapY) && !isNaN(mapZoom)) {
 	 map.zoom({ x: mapX, y: mapY, k: mapZoom })
        * }
@@ -153,7 +153,7 @@ const Map = props => {
 	 }
 	 if (props.zoomIn) {
 	 map.zoomIn(props.zoomIn)
-	 } 
+	 }
        */
     map.width = size.width
   }

--- a/src/components/data-viz/Map/Map.js
+++ b/src/components/data-viz/Map/Map.js
@@ -17,10 +17,10 @@ const useStyles = makeStyles(theme => ({
   root: {
     height: '100%',
     width: '100%',
-    '& .mapContainer': {
-      height: '100%',
-      width: '100%',
-    },
+      '& .mapContainer': {
+	height: '100%',
+	width: '100%',
+      },
     '& .map': {
       height: '100%',
       width: '100%',
@@ -48,6 +48,7 @@ const useStyles = makeStyles(theme => ({
       }
     }
   }
+    
 }))
 
 /**
@@ -86,13 +87,13 @@ const Map = props => {
   const classes = useStyles()
   const minColor = props.minColor
   const maxColor = props.maxColor
-  const onZoom = props.onZoom || function () {
+  const onZoom = props.onZoom_d || function () {
     console.debug('Map onZoom default')
   }
-  const onZoomEnd = props.onZoomEnd || function () {
+  const onZoomEnd = props.onZoomEnd_d || function () {
     console.debug('Map onZoomEnd default')
   }
-  const zoomIn = props.zoomIn || function () {
+  const zoomIn = props.zoomIn_d || function () {
     console.debug('Map zoomIn default')
   }
   const mapZoom = props.mapZoom
@@ -139,20 +140,21 @@ const Map = props => {
       options
     )
 
-    map.onZoom = onZoom
-    map.onZoomEnd = onZoomEnd
+      /* 
+       * map.onZoom = onZoom
+       * map.onZoomEnd = onZoomEnd
+       * 
+       * if (!isNaN(mapX) && !isNaN(mapY) && !isNaN(mapZoom)) {
+	 map.zoom({ x: mapX, y: mapY, k: mapZoom })
+       * }
 
-    if (!isNaN(mapX) && !isNaN(mapY) && !isNaN(mapZoom)) {
-      map.zoom({ x: mapX, y: mapY, k: mapZoom })
-    }
-
-    if (props.zoomTo) {
-      map.zoomTo(props.zoomTo)
-    }
-    if (props.zoomIn) {
-	  map.zoomIn(props.zoomIn)
-    }
-
+	 if (props.zoomTo) {
+       * map.zoomTo(props.zoomTo)
+	 }
+	 if (props.zoomIn) {
+	 map.zoomIn(props.zoomIn)
+	 } 
+       */
     map.width = size.width
   }
 

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -54,8 +54,8 @@ const useStyles = makeStyles(theme => ({
     paddingLeft: theme.spacing(0),
     paddingRight: theme.spacing(0),
     overflow: 'hidden',
-      zIndex: 1,
-      '& .map-overlay': {
+    zIndex: 1,
+    '& .map-overlay': {
 	  left: '0',
 	  right: '0',
 	  width: '100%',
@@ -64,34 +64,34 @@ const useStyles = makeStyles(theme => ({
 	  top: '0',
 	  transition: '.3s ease',
 	  opacity: 0,
-      },
-      '& .map-overlay.scrollable': {
+    },
+    '& .map-overlay.scrollable': {
 	  position: 'absolute',
 	  backgroundColor: 'rgba(0, 0, 0, .3)',
 	  zIndex: '300',
 	  pointerEvents: 'all',
 	  opacity: 0,
-      },
+    },
 
-      '& .map-overlay.active': {
+    '& .map-overlay.active': {
 	  position: 'absolute',
 	  backgroundColor: 'rgba(0, 0, 0, .3)',
 	  zIndex: '300',
 	  pointerEvents: 'all',
 	  opacity: 1,
-      }
+    }
 
   },
-    mapWrapper: {
-	width: '100%',
-	height: '100%',
-	position: 'absolute',
-	padding: 0,
-	overflow: 'hidden',
-	background: theme.palette.grey[200],
-	display: 'block',
-    },
-    cardContainer: {
+  mapWrapper: {
+    width: '100%',
+    height: '100%',
+    position: 'absolute',
+    padding: 0,
+    overflow: 'hidden',
+    background: theme.palette.grey[200],
+    display: 'block',
+  },
+  cardContainer: {
     width: 310,
     position: 'absolute',
     right: 15,
@@ -304,7 +304,7 @@ const MapContext = props => {
     year: StringParam,
   })
 
-    const [mapOverlay, setMapOverlay] = useState('scrollable')
+  const [mapOverlay, setMapOverlay] = useState('scrollable')
   // eslint-disable-next-line no-unused-vars
   const [mapActive, setMapActive] = useState(true)
 
@@ -389,7 +389,7 @@ const MapContext = props => {
   // setZoom
   const setZoom = (x, y, k) => {
     // console.log('Dont set zoom setZoom x,y,k: ', x, y, k)
-      /* setMapY(y)
+    /* setMapY(y)
        * setMapX(x)
        * setMapK(k)
 

--- a/src/components/sections/ExploreData/MapContext.js
+++ b/src/components/sections/ExploreData/MapContext.js
@@ -54,35 +54,44 @@ const useStyles = makeStyles(theme => ({
     paddingLeft: theme.spacing(0),
     paddingRight: theme.spacing(0),
     overflow: 'hidden',
-    zIndex: 1,
-    '& .map-overlay': {
-      left: '0',
-      right: '0',
-      width: '100%',
-      height: '100%',
-      bottom: '0',
-      top: '0',
-      transition: '.3s ease',
-      opacity: 0,
+      zIndex: 1,
+      '& .map-overlay': {
+	  left: '0',
+	  right: '0',
+	  width: '100%',
+	  height: '100%',
+	  bottom: '0',
+	  top: '0',
+	  transition: '.3s ease',
+	  opacity: 0,
+      },
+      '& .map-overlay.scrollable': {
+	  position: 'absolute',
+	  backgroundColor: 'rgba(0, 0, 0, .3)',
+	  zIndex: '300',
+	  pointerEvents: 'all',
+	  opacity: 0,
+      },
+
+      '& .map-overlay.active': {
+	  position: 'absolute',
+	  backgroundColor: 'rgba(0, 0, 0, .3)',
+	  zIndex: '300',
+	  pointerEvents: 'all',
+	  opacity: 1,
+      }
+
+  },
+    mapWrapper: {
+	width: '100%',
+	height: '100%',
+	position: 'absolute',
+	padding: 0,
+	overflow: 'hidden',
+	background: theme.palette.grey[200],
+	display: 'block',
     },
-    '& .map-overlay.active': {
-      position: 'absolute',
-      backgroundColor: 'rgba(0, 0, 0, .3)',
-      zIndex: '300',
-      pointerEvents: 'all',
-      opacity: 1,
-    }
-  },
-  mapWrapper: {
-    width: '100%',
-    height: '100%',
-    position: 'absolute',
-    padding: 0,
-    overflow: 'hidden',
-    background: theme.palette.grey[200],
-    display: 'block',
-  },
-  cardContainer: {
+    cardContainer: {
     width: 310,
     position: 'absolute',
     right: 15,
@@ -295,7 +304,7 @@ const MapContext = props => {
     year: StringParam,
   })
 
-  const [mapOverlay, setMapOverlay] = useState(false)
+    const [mapOverlay, setMapOverlay] = useState('scrollable')
   // eslint-disable-next-line no-unused-vars
   const [mapActive, setMapActive] = useState(true)
 
@@ -322,11 +331,11 @@ const MapContext = props => {
   // handler
   const handler = () => {
     if (window.pageYOffset > 0) {
-      setMapOverlay(true)
+      setMapOverlay('active')
       setMapActive(false)
     }
     else {
-      setMapOverlay(false)
+      setMapOverlay('scrollable')
       setMapActive(true)
     }
   }
@@ -379,13 +388,13 @@ const MapContext = props => {
 
   // setZoom
   const setZoom = (x, y, k) => {
-    console.log('setZoom x,y,k: ', x, y, k)
-    setMapY(y)
-    setMapX(x)
-    setMapK(k)
+    // console.log('Dont set zoom setZoom x,y,k: ', x, y, k)
+      /* setMapY(y)
+       * setMapX(x)
+       * setMapK(k)
 
-    updateExploreDataMapZoom({ ...pageState, mapZoom: { mapX: x, mapY: y, mapZoom: k } })
-  }
+       * updateExploreDataMapZoom({ ...pageState, mapZoom: { mapX: x, mapY: y, mapZoom: k } })
+       */ }
 
   // check width, set zoom
   useEffect(() => {
@@ -589,7 +598,9 @@ const MapContext = props => {
               {mapChild}
               <MapControls handleClick={handleClick} />
             </Box>
-            <Box className={`map-overlay ${ mapOverlay ? 'active' : '' }`}></Box>
+            <Box className={`map-overlay ${ mapOverlay }`}
+		 onClick={ () => setMapOverlay('') }
+	    ></Box>
           </Grid>
           { matchesMdUp &&
             <Grid item xs={12}>


### PR DESCRIPTION
Fixes #1044

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1044-ZoomAndPanOptions/)


Changes proposed in this pull request:

Pulled state variables for zoom from  MapContext for much better performance.   The d3 map was rerendering on every pan and zoom.   Added logic to scroll until map is clicked on.  However on scroll still causes map to rerender.  So does changing to county and I don't think it needs too.   This is still a work in progress because it has caused the zoom and reset buttons to no longer work.  And there  are more performance gains to be had by moving map controls into the map. 

Todo:

Put zoom and reset buttons in D3
Put mapover lay into D3 so it does cause map to rerender.  This will perform better, but also get rid of the bug where when you scroll down out of map the map resets its zoom.
Put state vs county control into map as well because then d3 won't have to rerender (I think)

-
-
-