### PR TITLE
Change H1s to title case Native American pages

### DIFF
--- a/src/pages/how-revenue-works/native-american-economic-impact.mdx
+++ b/src/pages/how-revenue-works/native-american-economic-impact.mdx
@@ -14,7 +14,7 @@ tags:
 
 [How revenue works](/how-revenue-works/) /
 
-# Impact of natural resource extraction on Native American land
+# Impact of Natural Resource Extraction on Native American Land
 
 Extraction affects Native American economies in a number of ways, though the effects can vary widely depending on the level of extraction on a given reservation and the details of the lease agreement.
 
@@ -37,4 +37,3 @@ Reclamation activity has occurred or needs to occur on 17 reservations. Three tr
 AML reclamation work has been conducted with 14 additional tribes that do not regulate their own AML programs. These tribes, and states like them, are called non-primacy tribes. The majority of identified reclamation has occurred; only five tribes (plus the Navajo Nation) have unfunded reclamation needs.
 
 OSMRE’s [annual evaluation reports](https://www.odocs.osmre.gov/) on Native American AML programs provide more information on the state and history of each AML program, including its status, unfunded costs, and completed costs. The [OSMRE Grant Resources page](https://www.osmre.gov/resources/grants.shtm) provides annual grant reports.
-

--- a/src/pages/how-revenue-works/native-american-ownership-governance.mdx
+++ b/src/pages/how-revenue-works/native-american-ownership-governance.mdx
@@ -17,7 +17,7 @@ tags:
 
 [How revenue works](/how-revenue-works/) /
 
-# Native American ownership and governance of natural resources
+# Native American Ownership and Governance of Natural Resources
 
 Native American land ownership involves a complex patchwork of titles, restrictions, obligations, statutes, and regulations. Extracting natural resources on Native American lands and distributing the associated revenue is a unique process involving multiple stakeholders.
 

--- a/src/pages/how-revenue-works/native-american-production.mdx
+++ b/src/pages/how-revenue-works/native-american-production.mdx
@@ -14,7 +14,7 @@ tags:
 
 [How revenue works](/how-revenue-works/) /
 
-# Natural resource production on Native American land
+# Natural Resource Production on Native American Land
 
 Extracting natural resources on Native American lands and distributing the associated revenue is a unique process involving multiple stakeholders.
 

--- a/src/pages/how-revenue-works/native-american-revenue.mdx
+++ b/src/pages/how-revenue-works/native-american-revenue.mdx
@@ -17,7 +17,7 @@ tags:
 
 [How revenue works](/how-revenue-works/) /
 
-# Revenue from natural resources on Native American land
+# Revenue from Natural Resources on Native American Land
 
 Natural resources are increasingly a key source of income for many Native American tribes and individuals.
 


### PR DESCRIPTION
Partial fix for #1203
[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/Fix-capitalization/how-revenue-works#how-are-natural-resources-on-native-american-land-governed)

Changes proposed in this pull request:

- Fix H1 capitalization on all How Revenue Works, Native American pages

