### PR TITLE
add redirect of archive to archive.revenuedata.doi.gov

### DIFF
--- a/src/components/content-partials/Redirects.mdx
+++ b/src/components/content-partials/Redirects.mdx
@@ -170,6 +170,9 @@ redirects:
   newUrl: "/how-revenue-works/lwcf"
 - oldUrl: "/how-revenue-works/historic-preservation-fund/"
   newUrl: "/how-revenue-works/hpf"
+# Archive redirects
+- oldUrl: "/archive/"
+  newUrl: "https://archive.revenuedata.doi.gov/"
 # Blog redirects
 - oldUrl: "/blog/"
   newUrl: "https://blog-nrrd.doi.gov/"


### PR DESCRIPTION
Fixes #1195

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1195-ArchiveRedirect/)

Changes proposed in this pull request:

- adds redirect from /archive to https://archive.revenuedata.doi.gov/
-
-