### PR TITLE
update link, no date and space in prod header

### DIFF
--- a/src/components/info/SnapshotBanner/SnapshotBanner.js
+++ b/src/components/info/SnapshotBanner/SnapshotBanner.js
@@ -9,6 +9,8 @@ import Grid from '@material-ui/core/Grid'
 import { OnrrLogoImg } from '../../images'
 import { Typography } from '@material-ui/core'
 import Link from '../../Link'
+import PrintIcon from '@material-ui/icons/Print'
+import IconButton from '@material-ui/core/IconButton'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -51,6 +53,9 @@ const SnapshotBanner = () => {
           <Grid container>
             <Grid item xs={12}>
               <Box m={1} mr={2} style={{ fontSize: '1.1rem', lineHeight: '1.1rem', color: 'white', textAlign: 'end' }}>
+                <IconButton size="small" color='inherit' aria-label="print" component="span" onClick={() => window.print()} style={{ marginRight: '5px' }}>
+                  <PrintIcon />
+                </IconButton>
                 Monthly Snapshot
               </Box>
             </Grid>

--- a/src/components/info/SnapshotBanner/SnapshotBanner.js
+++ b/src/components/info/SnapshotBanner/SnapshotBanner.js
@@ -8,6 +8,7 @@ import Grid from '@material-ui/core/Grid'
 
 import { OnrrLogoImg } from '../../images'
 import { Typography } from '@material-ui/core'
+import Link from '../../Link'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -50,12 +51,12 @@ const SnapshotBanner = () => {
           <Grid container>
             <Grid item xs={12}>
               <Box m={1} mr={2} style={{ fontSize: '1.1rem', lineHeight: '1.1rem', color: 'white', textAlign: 'end' }}>
-                Monthly Snapshot: February 2021
+                Monthly Snapshot
               </Box>
             </Grid>
             <Grid item xs={12}>
               <Box style={{ fontSize: '0.9rem', lineHeight: '0.9rem', color: 'white', textAlign: 'end' }} mb={1} mr={2}>
-                View interactive charts at revenuedata.doi.gov
+                View interactive charts at <Link href={'https://revenuedata.doi.gov/'} style={{ color: 'white' }}>revenuedata.doi.gov</Link>
               </Box>
             </Grid>
           </Grid>

--- a/src/pages/fact-sheet.mdx
+++ b/src/pages/fact-sheet.mdx
@@ -64,17 +64,17 @@ import { RECIPIENT, SOURCE, REVENUE_TYPE } from '../constants'
     </Grid>
     <Grid item xs={4}>
       <Box pl={'10px'} pr={'10px'}>
-        <ProductionLastTwelveMonths title='Oil(bbl)' filterByProduct='Oil (bbl)' units='bbl' yGroupBy={SOURCE} chartHeight={120} skeletonHeight={2783} disableInteraction={true} />
+        <ProductionLastTwelveMonths title='Oil (bbl)' filterByProduct='Oil (bbl)' units='bbl' yGroupBy={SOURCE} chartHeight={120} skeletonHeight={2783} disableInteraction={true} />
       </Box>
     </Grid>
     <Grid item xs={4}>
       <Box pl={'10px'} pr={'10px'}>
-        <ProductionLastTwelveMonths title='Gas(mcf)' filterByProduct='Gas (mcf)' units='mcf' yGroupBy={SOURCE} chartHeight={120} skeletonHeight={283} disableInteraction={true} />
+        <ProductionLastTwelveMonths title='Gas (mcf)' filterByProduct='Gas (mcf)' units='mcf' yGroupBy={SOURCE} chartHeight={120} skeletonHeight={283} disableInteraction={true} />
       </Box>
     </Grid>
     <Grid item xs={4}>
       <Box pl={'10px'} pr={'10px'}>
-        <ProductionLastTwelveMonths title='Coal(tons)' filterByProduct='Coal (tons)' units='tons' yGroupBy={SOURCE} chartHeight={120} skeletonHeight={283} disableInteraction={true} />
+        <ProductionLastTwelveMonths title='Coal (tons)' filterByProduct='Coal (tons)' units='tons' yGroupBy={SOURCE} chartHeight={120} skeletonHeight={283} disableInteraction={true} />
       </Box>
     </Grid>
   </Grid>


### PR DESCRIPTION
Fixes #1392

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1392-update-fact-sheet/)

Changes proposed in this pull request:

- Update header with a link to revenuedata.doi.gov
- Remove date in header
- Add space between product and units in the production graphs