### PR TITLE
change label

### DIFF
--- a/src/pages/downloads/federal-revenue-by-company.mdx
+++ b/src/pages/downloads/federal-revenue-by-company.mdx
@@ -86,7 +86,7 @@ _Commodity Type_ The DOI collects revenues on over 60 different products. The ma
 * _Mineral Materials_ (see below)
 * _N/A_
 * _Oil_
-* _Oil & Gas
+* _Oil & Gas_
 * _Oil Shale_
 * _Other Commodities_ (see below)
 * _Other Leasable Minerals_

--- a/src/pages/downloads/federal-revenue-by-company.mdx
+++ b/src/pages/downloads/federal-revenue-by-company.mdx
@@ -42,9 +42,9 @@ Disclosing payments of solid mineral companies who produce and sell only one pro
 
 Companies can adjust and correct their payments for up to seven years after a transaction takes place. If a company overpays their royalty, rent, or bonus, they are entitled to recoup their overpayment. If the overpayment and recoupment happen in different years, the recoupment will appear as a negative amount in ONRR’s revenue summaries.
 
-### Why is there a Gas value, an Oil value and an Oil or Gas (pre-production) value?
+### Why is there a Gas value, an Oil value and an Oil & Gas value?
 
-“Oil or Gas (pre-production)” is the commodity category used for offshore oil and gas rents and bonuses. At the time of lease sale, it isn’t known whether a lease will produce oil, gas, or both oil and gas. After a lease starts producing a commodity (or commodities), the lease owner starts paying royalties, and these royalties can then be associated with either oil or gas. Hence, rent and bonus lines of data will be associated with an “Oil or Gas (pre-production)” commodity type, while royalty lines of data will be associated with either “Oil” or “Gas” commodity types.
+“Oil & Gas” is the commodity category used for offshore oil and gas rents and bonuses. At the time of lease sale, it isn’t known whether a lease will produce oil, gas, or both oil and gas. After a lease starts producing a commodity (or commodities), the lease owner starts paying royalties, and these royalties can then be associated with either oil or gas. Hence, rent and bonus lines of data will be associated with an “Oil & Gas” commodity type, while royalty lines of data will be associated with either “Oil” or “Gas” commodity types.
 
 ### Why is the calendar year revenue by location national total slightly different than the federal revenue by company total?
 
@@ -86,7 +86,7 @@ _Commodity Type_ The DOI collects revenues on over 60 different products. The ma
 * _Mineral Materials_ (see below)
 * _N/A_
 * _Oil_
-* _Oil or Gas_ (pre-production)
+* _Oil & Gas
 * _Oil Shale_
 * _Other Commodities_ (see below)
 * _Other Leasable Minerals_

--- a/src/pages/downloads/revenue.mdx
+++ b/src/pages/downloads/revenue.mdx
@@ -56,9 +56,9 @@ The data is presented by month, from January 2003 through the most recently comp
 
 Companies can adjust and correct their payments for up to seven years after a transaction takes place. If a company overpays their royalty, rent, or bonus, they are entitled to recoup their overpayment. If the overpayment and recoupment happen in different years, the recoupment will appear as a negative amount in the Office of Natural Resources Revenue's revenue summaries.
 
-### Why is there a Gas value, an Oil value and an Oil or Gas (pre-production) value?
+### Why is there a Gas value, an Oil value and an Oil & Gas (pre-production) value?
 
-“Oil or Gas (pre-production)” is the commodity category used for offshore oil and gas rents and bonuses. At the time of lease sale, it isn’t known whether a lease will produce oil, gas or both oil and gas. After a lease starts producing a commodity (or commodities), the lease owner starts paying royalties. These can then be associated with either oil or gas. Hence, rent and bonus lines of data will be associated with an “Oil or Gas (pre-production)” commodity type, while royalty lines of data will be associated with either “Oil” or “Gas” commodity types.
+“Oil & Gas (pre-production)” is the commodity category used for offshore oil and gas rents and bonuses. At the time of lease sale, it isn’t known whether a lease will produce oil, gas or both oil and gas. After a lease starts producing a commodity (or commodities), the lease owner starts paying royalties. These can then be associated with either oil or gas. Hence, rent and bonus lines of data will be associated with an “Oil & Gas (pre-production)” commodity type, while royalty lines of data will be associated with either “Oil” or “Gas” commodity types.
 
 ### Why are federal revenue by company totals different from calendar year totals calculated from the monthly data?
 
@@ -172,7 +172,7 @@ _Commodity_ The Department of the Interior collects revenues on over 60 differen
 * _Molybdenum Concentrate_
 * _NGL_
 * _Oil_
-* _Oil or Gas (pre-production)_
+* _Oil & Gas (pre-production)_
 * _Oil Shale_
 * _Phosphate_
 * _Potassium_

--- a/src/pages/downloads/revenue.mdx
+++ b/src/pages/downloads/revenue.mdx
@@ -131,7 +131,7 @@ _Mineral Lease Type_ Is the type of lease revenue is being generated from. An oi
 * _Hot Springs_
 * _Limestone_
 * _Mining - Unspecified_
-* _Oil & Gas
+* _Oil & Gas_
 * _Oil Shale_
 * _Phosphate_
 * _Potassium_


### PR DESCRIPTION
Fixes #<PUT ISSUE NUM HERE>

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/update-oil&gas-label/)

Changes proposed in this pull request:

- on revenue download page change to Oil & gas (pre-production)
- on revenue by company change to Oil & gas since we didn't implement that change in the database yet for that file.
-