### PR TITLE
Create for data review PR

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,3 @@
-GATSBY_HASURA_URI="https://hasura-dev.app.cloud.gov/v1/graphql"
+GATSBY_HASURA_URI="https://hasura-sandbox.app.cloud.gov/v1/graphql"
 GTM_ID="GTM-NCRF98R"
 isShutdown=false

--- a/src/components/data-viz/ProductionLastTwelveMonths/ProductionLastTwelveMonths.js
+++ b/src/components/data-viz/ProductionLastTwelveMonths/ProductionLastTwelveMonths.js
@@ -25,7 +25,7 @@ const ProductionLastTwelveMonths = ({ title, disableInteraction, filterByProduct
   // TODO get rid of hardcoded order by
   // const yOrderByTest = [...new Set(data?.results.map(item => item.recipient))]
   const yOrderBy = (yGroupBy === SOURCE)
-    ? ['Native American', 'Federal Offshore', 'Federal Onshore']
+    ? ['Native American', 'Federal offshore', 'Federal onshore']
     : ['Other Revenues', 'Inspection Fees', 'Civil Penalties', 'Rents', 'Bonus', 'Royalties']
 
   const xGroups = data?.results?.filter(row => row.product === filterByProduct).reduce((g, row, i) => {

--- a/src/components/data-viz/RevenueLastTwelveMonths/RevenueLastTwelveMonths.js
+++ b/src/components/data-viz/RevenueLastTwelveMonths/RevenueLastTwelveMonths.js
@@ -25,7 +25,7 @@ const RevenueLastTwelveMonths = ({ title, disableInteraction, yGroupBy, data, ch
   // TODO get rid of hardcoded order by
   // const yOrderByTest = [...new Set(data?.results.map(item => item.recipient))]
   const yOrderBy = (yGroupBy === SOURCE)
-    ? ['Federal - not tied to a lease', 'Native American', 'Federal Offshore', 'Federal Onshore']
+    ? ['Federal - not tied to a lease', 'Native American', 'Federal offshore', 'Federal onshore']
     : ['Other Revenues', 'Inspection Fees', 'Civil Penalties', 'Rents', 'Bonus', 'Royalties']
 
   const xGroups = data?.results.reduce((g, row, i) => {

--- a/src/components/sections/TotalDisbursements/TotalDisbursements.js
+++ b/src/components/sections/TotalDisbursements/TotalDisbursements.js
@@ -135,7 +135,7 @@ const TotalDisbursements = props => {
       'State and local governments',
       'U.S. Treasury'
     ]
-    : ['Native American', 'Federal Offshore', 'Federal Onshore']
+    : ['Native American', 'Federal offshore', 'Federal onshore']
 
   if (error) return `Error! ${ error.message }`
   if (data) {

--- a/src/components/sections/TotalProduction/TotalProduction.js
+++ b/src/components/sections/TotalProduction/TotalProduction.js
@@ -105,7 +105,7 @@ const TotalProduction = props => {
   let xAxis = 'year'
   const yAxis = 'sum'
   const yGroupBy = 'source'
-  const yOrderBy = ['Native American', 'Federal Offshore', 'Federal Onshore']
+  const yOrderBy = ['Native American', 'Federal offshore', 'Federal onshore']
   let xLabels
   let maxFiscalYear
   let maxCalendarYear

--- a/src/components/sections/TotalRevenue/TotalRevenue.js
+++ b/src/components/sections/TotalRevenue/TotalRevenue.js
@@ -226,7 +226,7 @@ const TotalRevenue = props => {
     yOrderBy = ['Not tied to a commodity', 'Other commodities', 'Coal', 'Gas', 'Oil']
     break
   default:
-    yOrderBy = ['Federal - not tied to a lease', 'Native American', 'Federal Offshore', 'Federal Onshore']
+    yOrderBy = ['Federal - not tied to a lease', 'Native American', 'Federal offshore', 'Federal onshore']
     break
   }
 

--- a/src/components/sections/TotalRevenue/TotalRevenue.js
+++ b/src/components/sections/TotalRevenue/TotalRevenue.js
@@ -220,7 +220,7 @@ const TotalRevenue = props => {
 
   switch (breakoutBy) {
   case 'revenue_type':
-    yOrderBy = ['Other Revenues', 'Inspection Fees', 'Civil Penalties', 'Rents', 'Bonus', 'Royalties']
+    yOrderBy = ['Other revenues', 'Inspection fees', 'Civil penalties', 'Rents', 'Bonus', 'Royalties']
     break
   case 'commodity':
     yOrderBy = ['Not tied to a commodity', 'Other commodities', 'Coal', 'Gas', 'Oil']


### PR DESCRIPTION
Fixes #921, #629

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/921-FixCapitalization/)

Changes proposed in this pull request:

Commodity and product have regexp to change to first char upper the rest lower

Change units on Geothermal

- [x] Sand/gravel-cubic yards  [_Comes from file like this it might have meaningless (cyd) certainly I can provide a 1 off for this]_
- [x]  Oil & gas (pre-production) - disbursements  _[ I was having a hard time finding commodity in site for disbursments so I didn't apply all logic (same for lead zinc)]_
- [x] Lead/Zinc  - disbursements 
- [x] Revenue by company _[Never even looked at it]_
- @mojo why is this commodity displaying in the drop-down if there was no production nationwide for the whole range of years? _negative number or zero.    I think this falls under different issue_

- [ ] 

-
-
-