### PR TITLE
removed extra column in header for revenue

### DIFF
--- a/src/components/data-viz/RevenueLastTwelveMonths/RevenueLastTwelveMonths.js
+++ b/src/components/data-viz/RevenueLastTwelveMonths/RevenueLastTwelveMonths.js
@@ -52,7 +52,7 @@ const RevenueLastTwelveMonths = ({ title, disableInteraction, yGroupBy, data, ch
     const month = date.toLocaleString('default', { month: 'short' })
     const year = headers[1].substring(0, 4)
     const name = (yGroupBy === 'revenue_type') ? 'Revenue type' : DISPLAY_NAMES[headers[0]]?.default
-    const headerArr = [name, '', `${ month } ${ year }`]
+    const headerArr = [name, `${ month } ${ year }`]
     return headerArr
   }
 


### PR DESCRIPTION
Fixes #1495

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/1495-fix-monthly-snap/fact-sheet)

Changes proposed in this pull request:

- Columns align in Revenue section with header
-
-