### PR TITLE
Left nav

### DIFF
--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -450,3 +450,11 @@ Data about revenue from the extractive industries is subject to a number of cont
 </Grid>
 </Grid>
 </Container>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -50,7 +50,7 @@ Learn about the process of natural resource extraction in the U.S. from land own
 </Grid>
 <Grid item xs={12} sm={9}>
 
-<h2 alt='How data fits'>How our data fits together</h2>
+<h2 alt='Our data'>How our data fits together</h2>
 
 ---
 <Grid container

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -50,7 +50,7 @@ Learn about the process of natural resource extraction in the U.S. from land own
 </Grid>
 <Grid item xs={12} sm={9}>
 
-<h2 alt='Site data'>What data is on this site?</h2>
+<h2 alt='How data fits'>How our data fits together</h2>
 
 ---
 <Grid container

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -446,14 +446,14 @@ The Gulf of Mexico Energy Security Act (GOMESA) created a revenue-sharing model 
 Data about revenue from the extractive industries is subject to a number of controls, standards, and regulations.
 
 [Learn about audits and assurances](/how-revenue-works/audits-and-assurances)
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
 </Grid>
 </Grid>
 </Container>

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -449,12 +449,4 @@ Data about revenue from the extractive industries is subject to a number of cont
 
 </Grid>
 </Grid>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
 </Container>

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -446,7 +446,14 @@ The Gulf of Mexico Energy Security Act (GOMESA) created a revenue-sharing model 
 Data about revenue from the extractive industries is subject to a number of controls, standards, and regulations.
 
 [Learn about audits and assurances](/how-revenue-works/audits-and-assurances)
-
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
 </Grid>
 </Grid>
 </Container>

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -63,7 +63,7 @@ Learn about the process of natural resource extraction in the U.S. from land own
       <Tabtastic selectedTab={props.location.search} enableDataFilterContext={false} processCardTabStyle={true}>
         <TabtasticTab label="Description">
           <Box fontSize={16}>
-            The data on this website is for energy and minerals on federal lands, <GlossaryTerm>Native American lands</GlossaryTerm>, and the <GlossaryTerm>Outer Continental Shelf</GlossaryTerm>. Private individuals, corporations and state and local governments can also buy and own land. Whomever owns the land also owns the oil, gas, coal, and other minerals found below the surface.
+            The data on this website is for energy and minerals on federal lands, <GlossaryTerm>Native American lands</GlossaryTerm>, and the <GlossaryTerm>Outer Continental Shelf</GlossaryTerm>. Private individuals, corporations, and state and local governments can also buy and own land. Whomever owns the land also owns the oil, gas, coal, and other minerals found below the surface.
           </Box>
         </TabtasticTab>
         <TabtasticTab label="Types">
@@ -183,7 +183,7 @@ Learn about the process of natural resource extraction in the U.S. from land own
       <Tabtastic selectedTab={props.location.search} enableDataFilterContext={false} processCardTabStyle={true}>
         <TabtasticTab label="Description">
           <Box fontSize={16}>
-            ONRR collects revenues for leases, sales and production and then disburses them. ONRR reports revenue data in accounting year, which is every sale that is accounted for in a given period regardless of when the sale took place. Company revenue includes revenues by production phase and commodity by company. This dataset includes revenues for U.S. federal lands and offshore areas.
+            ONRR collects revenues for leases, sales, and production and then disburses them. ONRR reports revenue data in accounting year, which is every sale that is accounted for in a given period regardless of when the sale took place. Company revenue includes revenues by production phase and commodity by company. This dataset includes revenues for U.S. federal lands and offshore areas.
             <br />
             <Link href='/query-data/?dataType=Revenue' linkType='FilterTable'>Query revenue data</Link>
             <Link href='/query-data/?dataType=Federal revenue by company' linkType='FilterTable'>Query company revenue data</Link>

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -454,6 +454,14 @@ Data about revenue from the extractive industries is subject to a number of cont
 <br></br>
 <br></br>
 <br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
+<br></br>
 </Grid>
 </Grid>
 </Container>

--- a/src/pages/how-revenue-works/index.mdx
+++ b/src/pages/how-revenue-works/index.mdx
@@ -449,12 +449,12 @@ Data about revenue from the extractive industries is subject to a number of cont
 
 </Grid>
 </Grid>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
 </Container>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>


### PR DESCRIPTION
Fixes #369

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/left-nav/how-revenue-works)

Changes proposed in this pull request:

- Adds breaks to the bottom of the page, so the left nav highlights the right section
- Rewords title for how datasets fit section
- Adds Oxford commas to Ownership and Revenue cards